### PR TITLE
Issue #19: Set xPadding based on maximum y value.

### DIFF
--- a/widget/charts/line-simple.js
+++ b/widget/charts/line-simple.js
@@ -63,6 +63,18 @@ Line.prototype.setData = function(labels, data) {
 
       return max;
     }
+    
+    function getMaxXLabelPadding() {
+      return getMaxY().toString().length * 2;
+    }
+
+    if (getMaxXLabelPadding() > xLabelPadding) {
+      xLabelPadding = getMaxXLabelPadding();
+    };
+
+    if ((xPadding - xLabelPadding) < 0) {
+      xPadding = xLabelPadding;
+    }
 
     function getXPixel(val) {
         return ((self.canvasSize.width - xPadding) / data.length) * val + (xPadding * 1.5);


### PR DESCRIPTION
I added a function to calculate the maximum the xLabelPadding will need to be to accommodate the maximum y value.

The result of this is compared to to the previously defined xLabelPadding. If less than the max, the max is used.

If the label padding is greater than the xPadding the xPadding is set to the label padding so x is never negative for the labels. 