### PR TITLE
Y Labels are always integers, max Y should be an integer

### DIFF
--- a/widget/charts/line-simple.js
+++ b/widget/charts/line-simple.js
@@ -56,6 +56,7 @@ Line.prototype.setData = function(labels, data) {
       
       //max += 25 - max % 25;
       max*=1.2
+      max = Math.round(max);
 
       if (self.options.maxY) {
         return Math.max(max, self.options.maxY)


### PR DESCRIPTION
MaxY is already padded above the actually max y. This will round it to a whole number so that the theoretical maxY label will be a whole number just like the rest of the labels.