### PR TITLE
Ensure that there is always at least 3 pixels between the bars.

### DIFF
--- a/widget/charts/bar.js
+++ b/widget/charts/bar.js
@@ -12,6 +12,11 @@ function Bar(options) {
 
   this.options.barWidth = this.options.barWidth || 6
   this.options.barSpacing = this.options.barSpacing || 9
+
+  if ((this.options.barSpacing - this.options.barWidth) < 3) {
+    this.options.barSpacing = this.options.barWidth + 3;
+  }
+
   this.options.xOffset = this.options.xOffset || 5
   this.options.maxHeight = this.options.maxHeight || 7
   if (this.options.showText===false)


### PR DESCRIPTION
This allows a user to only set barWidth to something wider than barSpacing and it auto adjusts.

I think another way to do this is change barSpacing to mean the space between the bars. 