### PR TITLE
Add MIT license

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/yaronn/blessed-contrib.git"
   },
   "author": "Yaron Naveh (yaronn01@gmail.com)",
-  "license": "",
+  "license": "MIT",
   "devDependencies": {
     "blessed": "0.1.54"
   },


### PR DESCRIPTION
Without this, it is not possible to publish the library on webjars:

Failed! No valid licenses found. Detected licenses:  The acceptable licenses on BinTray are at: https://bintray.com/docs/api/#_footnote_1 License detection first uses the package metadata (e.g. package.json or bower.json) and falls back to looking for a LICENSE, LICENSE.txt, or LICENSE.md file in the master branch of the GitHub repo. Since these methods failed to detect a valid license you will need to work with the upstream project to add discoverable license metadata to a release or to the GitHub repo.