### PR TITLE
Changed the way donuts are drawn.

### DIFF
--- a/lib/widget/canvas.js
+++ b/lib/widget/canvas.js
@@ -33,7 +33,7 @@ Canvas.prototype.__proto__ = Box.prototype;
 Canvas.prototype.type = 'canvas';
 
 Canvas.prototype.calcSize = function() {
-    this.canvasSize = {width: this.width*2-12, height: this.height*4}
+    this.canvasSize = {width: this.width*2, height: this.height*4}
 }
 
 Canvas.prototype.clear = function() {

--- a/lib/widget/donut.js
+++ b/lib/widget/donut.js
@@ -1,6 +1,6 @@
 var blessed = require('blessed')
    , Node = blessed.Node
-   , Canvas = require('./canvas')
+   , Canvas = require('./canvas');
 
 function Donut(options) {
 
@@ -14,6 +14,7 @@ function Donut(options) {
   self.options.arcWidth = options.arcWidth || 4;
   self.options.spacing = options.spacing || 2;
   self.options.yPadding = options.yPadding || 2;
+  self.options.remainColor = options.remainColor || "black";
   self.options.data = options.data || [];
 
   if (!(this instanceof Node)) {
@@ -28,11 +29,11 @@ function Donut(options) {
 }
 
 Donut.prototype.calcSize = function() {
-    this.canvasSize = {width: Math.round(this.width*1.6), height: this.height*4-12}
+    this.canvasSize = {width: Math.round(this.width*2-5), height: this.height*4-12}
     if (this.canvasSize.width % 2 == 1)
-      this.canvasSize.width++;
-    if (this.canvasSize.width % 4 != 1)
-      this.canvasSize.width += (this.canvasSize.width % 4);
+      this.canvasSize.width--;
+    if (this.canvasSize.height % 4 != 1)
+      this.canvasSize.height += (this.canvasSize.height % 4);
 }
 
 Donut.prototype.__proto__ = Canvas.prototype;
@@ -52,6 +53,8 @@ Donut.prototype.update = function(data) {
     }
 
     var c = this.ctx
+    c.save();
+    c.translate(0,-this.options.yPadding);
 
     c.strokeStyle = this.options.stroke
     c.fillStyle = this.options.fill
@@ -60,9 +63,6 @@ Donut.prototype.update = function(data) {
 
     var cheight = this.canvasSize.height;
     var cwidth = this.canvasSize.width;
-
-    var cx = cwidth/2;
-    var cy = cheight/2;
 
     function makeRound(percent, radius, width, cx, cy, color){
       var s = 0;
@@ -83,6 +83,7 @@ Donut.prototype.update = function(data) {
           c.lineTo(Math.round(cx+s*cos(a)), Math.round(cy+s*sin(a)));
         }
         c.stroke();
+        c.closePath();
         s++;
       }
     }
@@ -91,12 +92,10 @@ Donut.prototype.update = function(data) {
     var donuts = data.length;
     var radius = this.options.radius;
     var width = this.options.arcWidth;
+    var remainColor = this.options.remainColor;
 
     var middle = cheight / 2;
-    var locations = (((cwidth / donuts) - (spacing * donuts)*donuts));
-    if (donuts == 1){
-      locations = locations/2;
-    }
+    var locations = (cwidth / (donuts + 1));
 
     if (data.length)
       makeDonuts(data);
@@ -110,18 +109,19 @@ Donut.prototype.update = function(data) {
     }
 
     function makeDonut(stat, which){
-        var left = (locations * which) + spacing;
+        var left = (locations * which);
         var percent = stat.percent;
         if (percent > 1.001){
           percent = parseFloat(percent / 100).toFixed(2);
         }
         var label = stat.label;
         var color = stat.color || "green";
-        var cxx = left;//(parseFloat((locations*which)) + 48);
+        var cxx = left;
         drawDonut(label, percent, radius, width, cxx, middle, color);
     }
 
     function drawDonut(label, percent, radius, width, cxx, middle, color){
+      makeRound(100, radius, width, cxx, middle, remainColor );
       makeRound(percent, radius, width, cxx, middle, color);
       var ptext = parseFloat(percent*100).toFixed(0) + "%";
       c.fillText(ptext, cxx - Math.round(parseFloat((c.measureText(ptext).width)/2)) + 3, middle);
@@ -129,6 +129,8 @@ Donut.prototype.update = function(data) {
     }
 
     c.strokeStyle = "magenta";
+
+    c.restore();
     return;
 }
 

--- a/lib/widget/donut.js
+++ b/lib/widget/donut.js
@@ -95,7 +95,7 @@ Donut.prototype.update = function(data) {
     var remainColor = this.options.remainColor;
 
     var middle = cheight / 2;
-    var locations = (cwidth / (donuts + 1));
+    var spacing = (cwidth - (donuts * radius * 2)) / (donuts + 1);
 
     if (data.length)
       makeDonuts(data);
@@ -109,7 +109,7 @@ Donut.prototype.update = function(data) {
     }
 
     function makeDonut(stat, which){
-        var left = (locations * which);
+        var left = radius + (spacing * which) + (radius * 2 * (which - 1))
         var percent = stat.percent;
         if (percent > 1.001){
           percent = parseFloat(percent / 100).toFixed(2);


### PR DESCRIPTION
Fixed canvas size calculations so we can use the whole space to draw the
donuts.
Removed option spacing. Now donuts will automatically space themselves
on the available space. Only constraints are radius.

Added remainColor option.

Example:
<img width="473" alt="untitled copy" src="https://cloud.githubusercontent.com/assets/120122/13195985/9c5dbc82-d7c1-11e5-8c8a-e20f0b6dddc1.png">

Of course remainColor can be black and the donut shows as before.