### PR TITLE
pass vi options from table to list to allow vi-key bindings.

### DIFF
--- a/examples/table.js
+++ b/examples/table.js
@@ -4,6 +4,7 @@ var blessed = require('blessed')
 
 var table = contrib.table(
    { keys: true
+   , vi: true
    , fg: 'white'
    , selectedFg: 'white'
    , selectedBg: 'blue'
@@ -20,9 +21,11 @@ screen.append(table)
 
 table.setData(
  { headers: ['col1', 'col2']
- , data: 
-  [ [1, 2] 
-  , [3, 4] ]})
+ , data:
+  [ [1, 2]
+  , [3, 4]
+  , [5, 6]
+  , [7, 8] ]})
 
 screen.key(['escape', 'q', 'C-c'], function(ch, key) {
   return process.exit(0);

--- a/lib/widget/table.js
+++ b/lib/widget/table.js
@@ -46,6 +46,7 @@ function Table(options) {
                     , bg: options.bg
                  }},
           keys: options.keys,
+          vi: options.vi,
           tags: true,
           interactive: options.interactive,
           screen: this.screen


### PR DESCRIPTION
@yaronn  for your consideration...

small change to allow `options.vi` to be passed to the underlying `list` so that vi-key bindings work as expected.

- modified example to turn on vi keys in order to test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yaronn/blessed-contrib/92)
<!-- Reviewable:end -->
