### PR TITLE
Fix gauge label float point rounding

### DIFF
--- a/lib/widget/gauge.js
+++ b/lib/widget/gauge.js
@@ -73,7 +73,7 @@ Gauge.prototype.setPercent = function(percent) {
       c.strokeStyle = 'normal'
     }
 
-    if (this.options.showLabel) c.fillText(percent+"%", textX, 3)
+    if (this.options.showLabel) c.fillText(Math.round(percent)+"%", textX, 3)
 }
 
 Gauge.prototype.setStack = function(stack) {


### PR DESCRIPTION
To prevent float point math errors from being shown in gauge label, the percent is rounded prior to being displayed.