### PR TITLE
Allows to zoom in by using maxY in lines, fixes #86

### DIFF
--- a/examples/line-zoomed-in.js
+++ b/examples/line-zoomed-in.js
@@ -1,0 +1,33 @@
+var blessed = require('blessed')
+, contrib = require('../index')
+, screen = blessed.screen()
+, line = contrib.line(
+   { width: 80
+   , height: 30
+   , left: 15
+   , top: 12
+   , xPadding: 5
+   , minY: 1000
+   , maxY: 1050
+   , label: 'Title'
+   , style: { baseline: 'white' }
+   })
+
+, data = [ { title: 'us-east',
+             x: ['t1', 't2', 't3', 't4'],
+             y: [1010, 1040, 1020, 1030],
+             style: {
+              line: 'red'
+             }
+           }
+        ]
+
+
+screen.append(line) //must append before setting data
+line.setData(data)
+
+screen.key(['escape', 'q', 'C-c'], function(ch, key) {
+  return process.exit(0);
+});
+
+screen.render()

--- a/lib/widget/charts/line.js
+++ b/lib/widget/charts/line.js
@@ -92,6 +92,9 @@ Line.prototype.setData = function(data) {
 //for some reason this loop does not properly get the maxY if there are multiple datasets (was doing 4 datasets that differred wildly)
 //just used lodash _.max utility
     function getMaxY() {
+      if (self.options.maxY) {
+        return self.options.maxY;
+      }
 
       var max = 0;
       var setMax = [];
@@ -111,9 +114,6 @@ Line.prototype.setData = function(data) {
 
       max = m*1.2;
       max*=1.2
-      if (self.options.maxY) {
-        return Math.max(max, self.options.maxY)
-      }
 
       return max;
     }


### PR DESCRIPTION
Fixes the problem discussed in #86. I also added an example.