### PR TITLE
fixed small typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Works on Linux, OS X and Windows. For Windows follow the [pre requisites](http:/
 
     npm install blessed blessed-contrib
 
-##Usage
+## Usage
 
 You can use any of the default widgets of [blessed](https://github.com/chjj/blessed) (texts, lists and etc) or the widgets added in blessed-contrib (described below). A [layout](#layouts) is optional but usefull for dashboards. The widgets in blessed-contrib follow the same usage pattern:
 


### PR DESCRIPTION
##Usage -> ## Usage

Hey, I just took a look at the readme and saw that there is a missing space in one of the headers