### PR TITLE
Fix max value of line graph

### DIFF
--- a/examples/line-start-above-zero.js
+++ b/examples/line-start-above-zero.js
@@ -8,7 +8,6 @@ var blessed = require('blessed')
    , top: 12
    , xPadding: 5
    , minY: 30
-   , maxY: 90
    , label: 'Title'
    , style: { baseline: 'white' }
    })

--- a/examples/line-zoomed-in.js
+++ b/examples/line-zoomed-in.js
@@ -1,0 +1,33 @@
+var blessed = require('blessed')
+, contrib = require('../index')
+, screen = blessed.screen()
+, line = contrib.line(
+   { width: 80
+   , height: 30
+   , left: 15
+   , top: 12
+   , xPadding: 5
+   , minY: 1000
+   , maxY: 1050
+   , label: 'Title'
+   , style: { baseline: 'white' }
+   })
+
+, data = [ { title: 'us-east',
+             x: ['t1', 't2', 't3', 't4'],
+             y: [1010, 1040, 1020, 1030],
+             style: {
+              line: 'red'
+             }
+           }
+        ]
+
+
+screen.append(line) //must append before setting data
+line.setData(data)
+
+screen.key(['escape', 'q', 'C-c'], function(ch, key) {
+  return process.exit(0);
+});
+
+screen.render()

--- a/lib/widget/charts/line.js
+++ b/lib/widget/charts/line.js
@@ -92,30 +92,22 @@ Line.prototype.setData = function(data) {
 //for some reason this loop does not properly get the maxY if there are multiple datasets (was doing 4 datasets that differred wildly)
 //just used lodash _.max utility
     function getMaxY() {
+      if (self.options.maxY) {
+        return self.options.maxY;
+      }
 
-      var max = 0;
-      var setMax = [];
+      var max = -Infinity;
 
       for(var i = 0; i < data.length; i++) {
-        if (data[i].y.length)
-          setMax[i] = _.max(data[i].y, getMax);
-
-        for(var j = 0; j < data[i].y.length; j++) {
-          if(data[i].y[j] > max) {
-            max = data[i].y[j];
+        if (data[i].y.length) {
+          var current = _.max(data[i].y, parseFloat);
+          if (current > max) {
+            max = current;
           }
         }
       }
 
-      var m = _.max(setMax, getMax);
-
-      max = m*1.2;
-      max*=1.2
-      if (self.options.maxY) {
-        return Math.max(max, self.options.maxY)
-      }
-
-      return max;
+      return max + (max - self.options.minY) * 0.2;
     }
 
     function formatYLabel(value, max, min, numLabels, wholeNumbersOnly, abbreviate) {

--- a/lib/widget/charts/line.js
+++ b/lib/widget/charts/line.js
@@ -89,8 +89,7 @@ Line.prototype.setData = function(data) {
     function getMax(v, i){
       return parseFloat(v);
     }
-//for some reason this loop does not properly get the maxY if there are multiple datasets (was doing 4 datasets that differred wildly)
-//just used lodash _.max utility
+
     function getMaxY() {
       if (self.options.maxY) {
         return self.options.maxY;


### PR DESCRIPTION
Make the line graph compute a sensitive default value for the max boundary and yield the user-defined maxY value if any.

This addresses #86 by extending the solution proposed in #98 . 

The current implementation of getMaxY contains two bugs:
1. The user-provided value can be overriden by the one computed (if the user provides a value, he wants to see that value, no black magic!)
2. The max value is scaled with respect to the origin but if the graph starts above the origin this prevents the dynamic range of the input value to be fully exploited, resulting in an almost flat line or even in a completely flat line in extreme cases.
3. (performance) The algorithm to compute a maximum seems convoluted and inefficient (unless I missed an important detail).