### PR TITLE
Upgrade picture-tube to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "ansi-term": ">=0.0.2",
-    "x256": ">=0.0.1",
     "chalk": "^1.1.0",
     "drawille-canvas-blessed-contrib": ">=0.1.3",
     "lodash": ">=3.0.0",
@@ -27,10 +26,11 @@
     "marked-terminal": "^1.5.0",
     "memory-streams": "^0.1.0",
     "memorystream": "^0.3.1",
-    "picture-tube": "git://github.com:zixia/picture-tube.git#patch-1",
+    "picture-tube": "github:zixia/picture-tube#patch-1",
     "request": "^2.53.0",
     "sparkline": "^0.1.1",
     "strip-ansi": "^3.0.0",
-    "term-canvas": "0.0.5"
+    "term-canvas": "0.0.5",
+    "x256": ">=0.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "marked-terminal": "^1.5.0",
     "memory-streams": "^0.1.0",
     "memorystream": "^0.3.1",
-    "picture-tube": "^1.0.0",
+    "picture-tube": "git://github.com:zixia/picture-tube.git#patch-1",
     "request": "^2.53.0",
     "sparkline": "^0.1.1",
     "strip-ansi": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "marked-terminal": "^1.5.0",
     "memory-streams": "^0.1.0",
     "memorystream": "^0.3.1",
-    "picture-tube": "0.0.4",
+    "picture-tube": "^1.0.0",
     "request": "^2.53.0",
     "sparkline": "^0.1.1",
     "strip-ansi": "^3.0.0",


### PR DESCRIPTION
To fix the future charm memory leak bug, which will cause the `contrib.picture.setImage` got the follow error after be called multiple times(after 11 times):
```shell
(node:20914) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 ^C listeners added. Use emitter.setMaxListeners() to increase limit
MaxListenersExceededWarning
Possible EventEmitter memory leak detected. 11 ^C listeners added. Use emitter.setMaxListeners() to increase limit
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 ^C listeners added. Use emitter.setMaxListeners() to increase limit
    at _addListener (events.js:281:19)
    at Charm.addListener [(events.js:298:10)](url)
    at Charm.once (events.js:342:8)
    at module.exports (/home/zixia/git/node-facenet/node_modules/picture-tube/node_modules/charm/index.js:45:11)
    at module.exports (/home/zixia/git/node-facenet/node_modules/picture-tube/index.js:13:13)
    at Picture.setImage (/home/zixia/git/node-facenet/node_modules/blessed-contrib/lib/widget/picture.js:31:14)
    at Promise (/home/zixia/git/node-facenet/bin/manager.contrib.ts:222:13)
    at Promise (<anonymous>)
    at /home/zixia/git/node-facenet/bin/manager.contrib.ts:221:10
    at Generator.next (<anonymous>)
```

See: 
1. https://github.com/substack/node-charm/issues/34
1. https://github.com/substack/picture-tube/pull/11