### PR TITLE
Grid options.hideBorder

### DIFF
--- a/lib/layout/grid.js
+++ b/lib/layout/grid.js
@@ -28,7 +28,7 @@ Grid.prototype.set = function(row, col, rowSpan, colSpan, obj, opts) {
    options.left = left + '%'
    options.width = (this.cellWidth * colSpan - widgetSpacing) + "%"
    options.height = (this.cellHeight * rowSpan - widgetSpacing) + "%"
-   if (!this.options.hideBorder)
+   if (options.hideBorder)
       options.border = {type: "line", fg: this.options.color || "cyan"}         
    
    var instance = obj(options)

--- a/lib/layout/grid.js
+++ b/lib/layout/grid.js
@@ -28,7 +28,7 @@ Grid.prototype.set = function(row, col, rowSpan, colSpan, obj, opts) {
    options.left = left + '%'
    options.width = (this.cellWidth * colSpan - widgetSpacing) + "%"
    options.height = (this.cellHeight * rowSpan - widgetSpacing) + "%"
-   if (options.hideBorder)
+   if (!options.hideBorder)
       options.border = {type: "line", fg: this.options.color || "cyan"}         
    
    var instance = obj(options)


### PR DESCRIPTION
I had the need to have one object with a different border  or more to the fact. no Border

Since  
> options = utils.MergeRecursive(options, opts)

makes a merge copy of the this.options and overwrites any value with opts there should be no problem

> -   if (!this.options.hideBorder)
>+   if (!options.hideBorder)