### PR TITLE
[tree] Fix tree widget mouse handling

### DIFF
--- a/lib/widget/tree.js
+++ b/lib/widget/tree.js
@@ -29,7 +29,7 @@ function Tree(options) {
     left: 1,
     style: options.style,
     padding: options.padding,
-    keys: true,
+    keys: options.keys,
     tags: options.tags,
     input: options.input,
     vi: options.vi,
@@ -41,7 +41,7 @@ function Tree(options) {
 
   this.append(this.rows);
 
-  this.rows.key(options.keys, function() {
+  this.rows.on('select', function() {
     var selectedNode = self.nodeLines[this.getItemIndex(this.selected)];
     if (selectedNode.children) {
       selectedNode.extended = !selectedNode.extended;


### PR DESCRIPTION
Instead of only listening to `list.key()`, which ignores mouse-clicks,
we use the `list`s own select event to re-propagate the `tree`s select
event.
This way the mouse-clicks also trigger the `select`.
Since the existing `options.keys` are also passed to the `blessed.list()`
and thus influence its `select` event, they should behave exactly the
way they did til now.