### PR TITLE
Fix line chart y-axis decimal logic

### DIFF
--- a/lib/widget/charts/line.js
+++ b/lib/widget/charts/line.js
@@ -110,7 +110,7 @@ Line.prototype.setData = function(data) {
     }
 
     function formatYLabel(value, max, min, numLabels, wholeNumbersOnly, abbreviate) {
-      var fixed = (max/numLabels<1 && value!=0 && !wholeNumbersOnly) ? 2 : 0
+      var fixed = (((max - min) / numLabels) < 1 && value!=0 && !wholeNumbersOnly) ? 2 : 0
       var res = value.toFixed(fixed)
       return abbreviate?utils.abbreviateNumber(res):res
     }


### PR DESCRIPTION
# Overview

Currently, the `formatYLabel` function only incorporates the `maxY` option when calculating if decimal places should be shown for y-axis labels. This works fine for most cases, but presents a problem if both `minY` and `maxY` options are present.

For example: If `minY = 100` and `maxY = 101`, it is impossible for the y-axis labels to show decimals (`100.25`, `100.50`, etc). It will always just round to the nearest whole number, which in this case, would be undesirable.

This PR, updates the logic so that the example above works as expected (i.e. shows decimals for y-axis labels) without breaking existing functionality.

# Changes

- Added logic to the `formatYLabel` function to incorporate the `minY` option when calculating fixed decimal places.