### PR TITLE
fix(picture): replace picture-tube

### DIFF
--- a/lib/widget/picture.js
+++ b/lib/widget/picture.js
@@ -2,7 +2,7 @@
 var blessed = require('blessed')
   , Node = blessed.Node
   , Box = blessed.Box
-  , pictureTube = require('picture-tube')
+  , pictureTube = require('picture-tuber')
   , fs = require('fs')
   , streams = require('memory-streams')
   , MemoryStream = require('memorystream')

--- a/package-lock.json
+++ b/package-lock.json
@@ -693,7 +693,7 @@
     },
     "event-stream": {
       "version": "0.9.8",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-0.9.8.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.9.8.tgz",
       "integrity": "sha1-XanPPHkAl1mJ21powo5bPJjr4Do=",
       "requires": {
         "optimist": "0.2"
@@ -1350,25 +1350,17 @@
         "pify": "^2.0.0"
       }
     },
-    "picture-tube": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picture-tube/-/picture-tube-1.0.0.tgz",
-      "integrity": "sha1-OhjazoyiBuO03JHsg8mC6Eba0UE=",
+    "picture-tuber": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picture-tuber/-/picture-tuber-1.0.1.tgz",
+      "integrity": "sha512-LibfKhbYkcMpkRvGbi96LwoCIonOmgulHooQtE6DoXI30YIu4lsQdJZKOP1SqD7vt2TIhHs6u6u6VK72dqLLaQ==",
       "requires": {
         "buffers": "~0.1.1",
         "charm": "~0.1.0",
         "event-stream": "~0.9.8",
         "optimist": "~0.3.4",
         "png-js": "~0.1.0",
-        "request": "~2.9.202",
         "x256": "~0.0.1"
-      },
-      "dependencies": {
-        "request": {
-          "version": "2.9.203",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.9.203.tgz",
-          "integrity": "sha1-bBcRpUB/uUoRQhlWPkQUW8v0cjo="
-        }
       }
     },
     "pify": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blessed-contrib",
-  "version": "4.8.10",
+  "version": "4.8.11",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "marked-terminal": "^1.5.0",
     "memory-streams": "^0.1.0",
     "memorystream": "^0.3.1",
-    "picture-tube": "^1.0.0",
+    "picture-tuber": "^1.0.1",
     "sparkline": "^0.1.1",
     "strip-ansi": "^3.0.0",
     "term-canvas": "0.0.5",


### PR DESCRIPTION
Replacing [picture-tube](https://github.com/substack/picture-tube) with a new module I created [picture-tuber](https://github.com/lirantal/picture-tuber) that strips down unused libs (request and tap)

/cc @binarymist @techieshark @chaz6 
