### PR TITLE
fix(line): remove lodash and implement getMax()

### DIFF
--- a/lib/widget/charts/line.js
+++ b/lib/widget/charts/line.js
@@ -3,7 +3,6 @@ var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('../canvas')
   , utils = require('../../utils.js')
-  , _ = require('lodash')
 
 function Line(options) {
   if (!(this instanceof Node)) {
@@ -93,7 +92,7 @@ Line.prototype.setData = function(data) {
 
     for(let i = 0; i < data.length; i++) {
       if (data[i].y.length) {
-        var current = _.max(data[i].y, parseFloat);
+        var current = getMax(data[i].y, parseFloat);
         if (current > max) {
           max = current;
         }
@@ -113,6 +112,21 @@ Line.prototype.setData = function(data) {
     var max = getMaxY()
 
     return formatYLabel(max, max, min, numLabels, wholeNumbersOnly, abbreviate).length * 2;
+  }
+
+  function getMax(collection, iteratee) {
+    const length = collection.length;
+    let maxValue = 0;
+    let currentValue = 0;
+
+    for (let i = 0; i <= length; i++) {
+      currentValue = iteratee(collection[i]);
+      if (currentValue >= maxValue) {
+        maxValue = currentValue;
+      }
+    }
+
+    return maxValue;
   }
 
   var maxPadding = getMaxXLabelPadding(this.options.numYLabels, this.options.wholeNumbersOnly, this.options.abbreviate, this.options.minY)


### PR DESCRIPTION
Removing lodash which is pulled in only for the sake of max, so I implemented that on it's own to reduce dependency bloat and security issues.

![image](https://user-images.githubusercontent.com/316371/53194556-4a987380-361c-11e9-85e2-80481a76eec2.png)

Source: https://snyk.io/vuln/npm:lodash