### PR TITLE
markdown breaks options.style

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -352,6 +352,12 @@ declare namespace BlessedContrib {
         }
 
         export interface MarkdownOptions extends CanvasOptions {
+          /** 
+           * Markdown text to render.
+           */
+          markdown?: string;
+
+          markdownStyle?: any;
         }
 
         export class MarkdownElement extends CanvasElement implements IHasOptions<MarkdownOptions> {

--- a/lib/widget/markdown.js
+++ b/lib/widget/markdown.js
@@ -13,9 +13,7 @@ function Markdown(options) {
 
   options = options || {};
 
-  this.evalStyles(options);
-
-  this.setOptions(options.style);
+  installMarked(options);
 
   this.options = options;
   Box.call(this, options);
@@ -25,37 +23,36 @@ function Markdown(options) {
 
 Markdown.prototype = Object.create(Box.prototype);
 
-Markdown.prototype.setOptions = function(style) {
+
+Markdown.prototype.setMarkdown = function(str) {
+  this.setContent(marked(str));
+}
+
+function installMarked(options) {
+
+  const style = Object.assign({}, options.markdownStyle|| {});
+
+  for (var st in style) {
+    if (typeof(style[st])!="string") continue;
+
+    var tokens = style[st].split('.');
+    style[st] = chalk;
+    for (var j=1; j<tokens.length; j++) {
+      style[st] = style[st][tokens[j]];
+    }
+
+  }
+  
   marked.setOptions({
     renderer: new TerminalRenderer(style)
   });
 
 }
 
-Markdown.prototype.setMarkdown = function(str) {
-  this.setContent(marked(str));
-}
-
-Markdown.prototype.evalStyles = function(options) {
-
-  if (!options.style) return;
-
-  for (var st in options.style) {
-    if (typeof(options.style[st])!="string") continue;
-
-    var tokens = options.style[st].split('.');
-    options.style[st] = chalk;
-    for (var j=1; j<tokens.length; j++) {
-      options.style[st] = options.style[st][tokens[j]];
-    }
-
-  }
-
-}
-
 Markdown.prototype.getOptionsPrototype = function() {
   return {
-    markdown: 'string'
+    markdown: 'string',
+    markdownStyle: 'object'
   }
 }
 

--- a/lib/widget/markdown.js
+++ b/lib/widget/markdown.js
@@ -13,7 +13,13 @@ function Markdown(options) {
 
   options = options || {};
 
-  installMarked(options);
+  const markdownOptions = {
+    style: options.markdownStyle
+  };
+
+  this.evalStyles(markdownOptions);
+
+  this.setOptions(markdownOptions.style);
 
   this.options = options;
   Box.call(this, options);
@@ -23,38 +29,35 @@ function Markdown(options) {
 
 Markdown.prototype = Object.create(Box.prototype);
 
-
 Markdown.prototype.setMarkdown = function(str) {
   this.setContent(marked(str));
-}
+};
 
-function installMarked(options) {
-
-  const style = Object.assign({}, options.markdownStyle|| {});
-
-  for (var st in style) {
-    if (typeof(style[st])!="string") continue;
-
-    var tokens = style[st].split('.');
-    style[st] = chalk;
-    for (var j=1; j<tokens.length; j++) {
-      style[st] = style[st][tokens[j]];
-    }
-
-  }
-  
+Markdown.prototype.setOptions = function(style) {
   marked.setOptions({
     renderer: new TerminalRenderer(style)
   });
+};
 
-}
+Markdown.prototype.evalStyles = function(options) {
+  if (!options.style) return;
+  for (var st in options.style) {
+    if (typeof(options.style[st])!="string") continue;
+
+    var tokens = options.style[st].split('.');
+    options.style[st] = chalk;
+    for (var j=1; j<tokens.length; j++) {
+      options.style[st] = options.style[st][tokens[j]];
+    }
+  }
+};
 
 Markdown.prototype.getOptionsPrototype = function() {
   return {
     markdown: 'string',
     markdownStyle: 'object'
   }
-}
+};
 
 Markdown.prototype.type = 'markdown';
 


### PR DESCRIPTION
https://github.com/yaronn/blessed-contrib/issues/168

 * don't override options.style
 * user able to provide custom markdown style object using options.markdownStyle
 * dont override setOptions()