### PR TITLE
Add more lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     "strict":["error", "global"],
     "no-undef":"error",
     "no-use-before-define": "off",
-    "indent": ["error", 2]
+    "indent": ["error", 2],
+    "semi": [2, "always"]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "no-undef":"error",
     "no-use-before-define": "off",
     "indent": ["error", 2],
-    "semi": [2, "always"]
+    "semi": [2, "always"],
+    "quotes": [2, "single"]
   }
 }

--- a/lib/layout/carousel.js
+++ b/lib/layout/carousel.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 function Carousel(pages, options) {
   this.currPage = 0;
   this.pages = pages;

--- a/lib/layout/carousel.js
+++ b/lib/layout/carousel.js
@@ -1,73 +1,73 @@
 "use strict";
 function Carousel(pages, options) {
-  this.currPage = 0
-  this.pages = pages
-  this.options = options
-  this.screen = this.options.screen
+  this.currPage = 0;
+  this.pages = pages;
+  this.options = options;
+  this.screen = this.options.screen;
 }
 
 Carousel.prototype.move = function() {
-  var i = this.screen.children.length
-  while (i--) this.screen.children[i].detach()
+  var i = this.screen.children.length;
+  while (i--) this.screen.children[i].detach();
 
   this.pages[this.currPage](this.screen, this.currPage);
-  this.screen.render()
-}
+  this.screen.render();
+};
 
 Carousel.prototype.next = function() {
-  this.currPage++
+  this.currPage++;
   if (this.currPage==this.pages.length){
     if (!this.options.rotate) {
       this.currPage--;
       return;
     } else {
-      this.currPage=0
+      this.currPage=0;
     }
   }
-  this.move()
-}
+  this.move();
+};
 
 Carousel.prototype.prev = function() {
-  this.currPage--
+  this.currPage--;
   if (this.currPage<0) {
     if (!this.options.rotate) {
       this.currPage++;
       return;
     } else {
-      this.currPage=this.pages.length-1
+      this.currPage=this.pages.length-1;
     }
   }
-  this.move()
-}
+  this.move();
+};
 
 Carousel.prototype.home = function() {
   this.currPage = 0;
   this.move();
-}
+};
 
 Carousel.prototype.end = function() {
   this.currPage = this.pages.length -1;
   this.move();
-}
+};
 
 Carousel.prototype.start = function() {
-  var self = this
+  var self = this;
 
-  this.move()
+  this.move();
 
   if (this.options.interval) {
-    setInterval(this.next.bind(this), this.options.interval)
+    setInterval(this.next.bind(this), this.options.interval);
   }
 
   if (this.options.controlKeys) {
     this.screen.key(['right', 'left', 'home', 'end'], function(ch, key) {
-      if (key.name=='right') self.next()
-      if (key.name=='left') self.prev()
-      if (key.name=='home') self.home()
-      if (key.name=='end') self.end()
+      if (key.name=='right') self.next();
+      if (key.name=='left') self.prev();
+      if (key.name=='home') self.home();
+      if (key.name=='end') self.end();
     });
   }
 
-}
+};
 
-module.exports = Carousel
+module.exports = Carousel;

--- a/lib/layout/grid.js
+++ b/lib/layout/grid.js
@@ -1,40 +1,40 @@
 "use strict";
-var utils = require('../utils')
+var utils = require('../utils');
 
-var widgetSpacing = 0
+var widgetSpacing = 0;
 
 function Grid(options) {
   if (!options.screen) throw "Error: A screen property must be specified in the grid options.\r\n" +
-                              "Note: Release 2.0.0 has breaking changes. Please refer to the README or to https://github.com/yaronn/blessed-contrib/issues/39"
-  this.options = options
-  this.options.dashboardMargin = this.options.dashboardMargin || 0
-  this.cellWidth = ((100 - this.options.dashboardMargin*2) / this.options.cols)
-  this.cellHeight = ((100  - this.options.dashboardMargin*2) / this.options.rows)
+                              "Note: Release 2.0.0 has breaking changes. Please refer to the README or to https://github.com/yaronn/blessed-contrib/issues/39";
+  this.options = options;
+  this.options.dashboardMargin = this.options.dashboardMargin || 0;
+  this.cellWidth = ((100 - this.options.dashboardMargin*2) / this.options.cols);
+  this.cellHeight = ((100  - this.options.dashboardMargin*2) / this.options.rows);
 }
 
 Grid.prototype.set = function(row, col, rowSpan, colSpan, obj, opts) {
 
   if (obj instanceof Grid) {
     throw "Error: A Grid is not allowed to be nested inside another grid.\r\n" +
-            "Note: Release 2.0.0 has breaking changes. Please refer to the README or to https://github.com/yaronn/blessed-contrib/issues/39"
+            "Note: Release 2.0.0 has breaking changes. Please refer to the README or to https://github.com/yaronn/blessed-contrib/issues/39";
   }
 
-  var top = row * this.cellHeight + this.options.dashboardMargin
-  var left = col * this.cellWidth + this.options.dashboardMargin
+  var top = row * this.cellHeight + this.options.dashboardMargin;
+  var left = col * this.cellWidth + this.options.dashboardMargin;
 
   //var options = JSON.parse(JSON.stringify(opts));
-  var options = {}
-  options = utils.MergeRecursive(options, opts)
-  options.top = top + '%'
-  options.left = left + '%'
-  options.width = (this.cellWidth * colSpan - widgetSpacing) + "%"
-  options.height = (this.cellHeight * rowSpan - widgetSpacing) + "%"
+  var options = {};
+  options = utils.MergeRecursive(options, opts);
+  options.top = top + '%';
+  options.left = left + '%';
+  options.width = (this.cellWidth * colSpan - widgetSpacing) + "%";
+  options.height = (this.cellHeight * rowSpan - widgetSpacing) + "%";
   if (!this.options.hideBorder)
-    options.border = {type: "line", fg: this.options.color || "cyan"}
+    options.border = {type: "line", fg: this.options.color || "cyan"};
 
-  var instance = obj(options)
-  this.options.screen.append(instance)
-  return instance
-}
+  var instance = obj(options);
+  this.options.screen.append(instance);
+  return instance;
+};
 
-module.exports = Grid
+module.exports = Grid;

--- a/lib/layout/grid.js
+++ b/lib/layout/grid.js
@@ -1,11 +1,11 @@
-"use strict";
+'use strict';
 var utils = require('../utils');
 
 var widgetSpacing = 0;
 
 function Grid(options) {
-  if (!options.screen) throw "Error: A screen property must be specified in the grid options.\r\n" +
-                              "Note: Release 2.0.0 has breaking changes. Please refer to the README or to https://github.com/yaronn/blessed-contrib/issues/39";
+  if (!options.screen) throw 'Error: A screen property must be specified in the grid options.\r\n' +
+                              'Note: Release 2.0.0 has breaking changes. Please refer to the README or to https://github.com/yaronn/blessed-contrib/issues/39';
   this.options = options;
   this.options.dashboardMargin = this.options.dashboardMargin || 0;
   this.cellWidth = ((100 - this.options.dashboardMargin*2) / this.options.cols);
@@ -15,8 +15,8 @@ function Grid(options) {
 Grid.prototype.set = function(row, col, rowSpan, colSpan, obj, opts) {
 
   if (obj instanceof Grid) {
-    throw "Error: A Grid is not allowed to be nested inside another grid.\r\n" +
-            "Note: Release 2.0.0 has breaking changes. Please refer to the README or to https://github.com/yaronn/blessed-contrib/issues/39";
+    throw 'Error: A Grid is not allowed to be nested inside another grid.\r\n' +
+            'Note: Release 2.0.0 has breaking changes. Please refer to the README or to https://github.com/yaronn/blessed-contrib/issues/39';
   }
 
   var top = row * this.cellHeight + this.options.dashboardMargin;
@@ -27,10 +27,10 @@ Grid.prototype.set = function(row, col, rowSpan, colSpan, obj, opts) {
   options = utils.MergeRecursive(options, opts);
   options.top = top + '%';
   options.left = left + '%';
-  options.width = (this.cellWidth * colSpan - widgetSpacing) + "%";
-  options.height = (this.cellHeight * rowSpan - widgetSpacing) + "%";
+  options.width = (this.cellWidth * colSpan - widgetSpacing) + '%';
+  options.height = (this.cellHeight * rowSpan - widgetSpacing) + '%';
   if (!this.options.hideBorder)
-    options.border = {type: "line", fg: this.options.color || "cyan"};
+    options.border = {type: 'line', fg: this.options.color || 'cyan'};
 
   var instance = obj(options);
   this.options.screen.append(instance);

--- a/lib/server-utils.js
+++ b/lib/server-utils.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var url = require('url')
   , contrib = require('../index')
   , blessed = require('blessed');
@@ -8,7 +8,7 @@ function OutputBuffer(options) {
   this.columns = options.cols;
   this.rows = options.rows;
   this.write = function(s) {
-    s = s.replace("\x1b8", ""); //not clear from where in blessed this code comes from. It forces the terminal to clear and loose existing content.
+    s = s.replace('\x1b8', ''); //not clear from where in blessed this code comes from. It forces the terminal to clear and loose existing content.
     options.res.write(s);
   };
 
@@ -47,7 +47,7 @@ function createScreen(req, res) {
   var rows = query.rows || 50;
 
   if (cols<=35 || cols>=500 || rows<=5 || rows>=300) {
-    serverError(req, res, "cols must be bigger than 35 and rows must be bigger than 5");
+    serverError(req, res, 'cols must be bigger than 35 and rows must be bigger than 5');
     return null;
   }
 

--- a/lib/server-utils.js
+++ b/lib/server-utils.js
@@ -1,72 +1,72 @@
 "use strict";
 var url = require('url')
   , contrib = require('../index')
-  , blessed = require('blessed')
+  , blessed = require('blessed');
 
 function OutputBuffer(options) {
-  this.isTTY = true
-  this.columns = options.cols
-  this.rows = options.rows
+  this.isTTY = true;
+  this.columns = options.cols;
+  this.rows = options.rows;
   this.write = function(s) {
-    s = s.replace("\x1b8", "") //not clear from where in blessed this code comes from. It forces the terminal to clear and loose existing content.
-    options.res.write(s)
-  }
+    s = s.replace("\x1b8", ""); //not clear from where in blessed this code comes from. It forces the terminal to clear and loose existing content.
+    options.res.write(s);
+  };
 
-  this.on = function() {}
+  this.on = function() {};
 }
 
 function InputBuffer() {
-  this.isTTY = true
-  this.isRaw = true
+  this.isTTY = true;
+  this.isRaw = true;
 
-  this.emit = function() {}
+  this.emit = function() {};
 
-  this.setRawMode = function() {}
-  this.resume = function() {}
-  this.pause = function() {}
+  this.setRawMode = function() {};
+  this.resume = function() {};
+  this.pause = function() {};
 
-  this.on = function() {}
+  this.on = function() {};
 }
 
 function serverError(req, res, err) {
   setTimeout(function() {
     if (!res.headersSent) res.writeHead(500, {'Content-Type': 'text/plain'});
-    res.write('\r\n\r\n'+err+'\r\n\r\n')
+    res.write('\r\n\r\n'+err+'\r\n\r\n');
     //restore cursor
-    res.end('\u001b[?25h')
-  }, 0)
+    res.end('\u001b[?25h');
+  }, 0);
 
-  return true
+  return true;
 }
 
 
 function createScreen(req, res) {
-  var query = url.parse(req.url, true).query
+  var query = url.parse(req.url, true).query;
 
-  var cols = query.cols || 250
-  var rows = query.rows || 50
+  var cols = query.cols || 250;
+  var rows = query.rows || 50;
 
   if (cols<=35 || cols>=500 || rows<=5 || rows>=300) {
-    serverError(req, res, "cols must be bigger than 35 and rows must be bigger than 5")
-    return null
+    serverError(req, res, "cols must be bigger than 35 and rows must be bigger than 5");
+    return null;
   }
 
   res.writeHead(200, {'Content-Type': 'text/plain'});
 
-  var output = new contrib.OutputBuffer({res: res, cols: cols, rows: rows})
-  var input = new contrib.InputBuffer() //required to run under forever since it replaces stdin to non-tty
-  var program = blessed.program({output: output, input: input})
+  var output = new contrib.OutputBuffer({res: res, cols: cols, rows: rows});
+  var input = new contrib.InputBuffer(); //required to run under forever since it replaces stdin to non-tty
+  var program = blessed.program({output: output, input: input});
 
-  if (query.terminal) program.terminal = query.terminal
-  if (query.isOSX) program.isOSXTerm = query.isOSX
-  if (query.isiTerm2) program.isiTerm2 = query.isiTerm2
+  if (query.terminal) program.terminal = query.terminal;
+  if (query.isOSX) program.isOSXTerm = query.isOSX;
+  if (query.isiTerm2) program.isiTerm2 = query.isiTerm2;
 
   var screen = blessed.screen({program: program});
-  return screen
+  return screen;
 }
 
 
-exports.createScreen = createScreen
-exports.OutputBuffer = OutputBuffer
-exports.InputBuffer = InputBuffer
-exports.serverError = serverError
+exports.createScreen = createScreen;
+exports.OutputBuffer = OutputBuffer;
+exports.InputBuffer = InputBuffer;
+exports.serverError = serverError;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var x256 = require('x256');
 
 /*
@@ -35,15 +35,15 @@ function MergeRecursive(obj1, obj2) {
 
 
 function getTypeName(thing){
-  if(thing===null)return "[object Null]"; // special case
+  if(thing===null)return '[object Null]'; // special case
   return Object.prototype.toString.call(thing);
 }
 
 function abbreviateNumber(value) {
   var newValue = value;
   if (value >= 1000) {
-    var suffixes = ["", "k", "m", "b","t"];
-    var suffixNum = Math.floor( (""+value).length/3 );
+    var suffixes = ['', 'k', 'm', 'b','t'];
+    var suffixNum = Math.floor( (''+value).length/3 );
     var shortValue = '';
     for (var precision = 2; precision >= 1; precision--) {
       shortValue = parseFloat( (suffixNum != 0 ? (value / Math.pow(1000,suffixNum) ) : value).toPrecision(precision));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,15 +1,15 @@
 "use strict";
-var x256 = require('x256')
+var x256 = require('x256');
 
 /*
 * Recursively merge properties of two objects
 */
 function MergeRecursive(obj1, obj2) {
   if (obj1==null) {
-    return obj2
+    return obj2;
   }
   if (obj2==null) {
-    return obj1
+    return obj1;
   }
 
   for (var p in obj2) {
@@ -65,8 +65,8 @@ function getColorCode(color) {
   }
 }
 
-exports.MergeRecursive = MergeRecursive
-exports.getTypeName = getTypeName
-exports.abbreviateNumber = abbreviateNumber
-exports.getColorCode = getColorCode
+exports.MergeRecursive = MergeRecursive;
+exports.getTypeName = getTypeName;
+exports.abbreviateNumber = abbreviateNumber;
+exports.getColorCode = getColorCode;
 

--- a/lib/widget/canvas.js
+++ b/lib/widget/canvas.js
@@ -2,30 +2,30 @@
 var blessed = require('blessed')
   , Node = blessed.Node
   , Box = blessed.Box
-  , InnerCanvas = require('drawille-canvas-blessed-contrib').Canvas
+  , InnerCanvas = require('drawille-canvas-blessed-contrib').Canvas;
 
 function Canvas(options, canvasType) {
 
-  var self = this
+  var self = this;
 
   if (!(this instanceof Node)) {
     return new Canvas(options);
   }
 
   options = options || {};
-  this.options = options
+  this.options = options;
   Box.call(this, options);
 
   this.on("attach", function() {
-    self.calcSize()
+    self.calcSize();
 
-    self._canvas = new InnerCanvas(this.canvasSize.width, this.canvasSize.height, canvasType)
-    self.ctx = self._canvas.getContext()
+    self._canvas = new InnerCanvas(this.canvasSize.width, this.canvasSize.height, canvasType);
+    self.ctx = self._canvas.getContext();
 
     if (self.options.data) {
-      self.setData(self.options.data)
+      self.setData(self.options.data);
     }
-  })
+  });
 }
 
 Canvas.prototype = Object.create(Box.prototype);
@@ -33,19 +33,19 @@ Canvas.prototype = Object.create(Box.prototype);
 Canvas.prototype.type = 'canvas';
 
 Canvas.prototype.calcSize = function() {
-  this.canvasSize = {width: this.width*2-12, height: this.height*4}
-}
+  this.canvasSize = {width: this.width*2-12, height: this.height*4};
+};
 
 Canvas.prototype.clear = function() {
   this.ctx.clearRect(0, 0, this.canvasSize.width, this.canvasSize.height);
-}
+};
 
 Canvas.prototype.render = function() {
 
   this.clearPos(true);
-  var inner = this.ctx._canvas.frame()
-  this.setContent(inner)
+  var inner = this.ctx._canvas.frame();
+  this.setContent(inner);
   return this._render();
 };
 
-module.exports = Canvas
+module.exports = Canvas;

--- a/lib/widget/canvas.js
+++ b/lib/widget/canvas.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Box = blessed.Box
@@ -16,7 +16,7 @@ function Canvas(options, canvasType) {
   this.options = options;
   Box.call(this, options);
 
-  this.on("attach", function() {
+  this.on('attach', function() {
     self.calcSize();
 
     self._canvas = new InnerCanvas(this.canvasSize.width, this.canvasSize.height, canvasType);

--- a/lib/widget/charts/bar.js
+++ b/lib/widget/charts/bar.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('../canvas');
@@ -25,7 +25,7 @@ function Bar(options) {
   else
     this.options.showText = true;
 
-  this.on("attach", function() {
+  this.on('attach', function() {
     if (self.options.data) {
       self.setData(self.options.data);
     }
@@ -41,7 +41,7 @@ Bar.prototype.calcSize = function() {
 Bar.prototype.setData = function(bar) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for bar charts must be called after the chart has been added to the screen via screen.append()";
+    throw 'error: canvas context does not exist. setData() for bar charts must be called after the chart has been added to the screen via screen.append()';
   }
 
   this.clear();

--- a/lib/widget/charts/bar.js
+++ b/lib/widget/charts/bar.js
@@ -1,54 +1,54 @@
 "use strict";
 var blessed = require('blessed')
   , Node = blessed.Node
-  , Canvas = require('../canvas')
+  , Canvas = require('../canvas');
 
 function Bar(options) {
   if (!(this instanceof Node)) {
     return new Bar(options);
   }
 
-  var self = this
+  var self = this;
 
   Canvas.call(this, options, require('ansi-term'));
 
-  this.options.barWidth = this.options.barWidth || 6
-  this.options.barSpacing = this.options.barSpacing || 9
+  this.options.barWidth = this.options.barWidth || 6;
+  this.options.barSpacing = this.options.barSpacing || 9;
 
   if ((this.options.barSpacing - this.options.barWidth) < 3) {
     this.options.barSpacing = this.options.barWidth + 3;
   }
 
-  this.options.xOffset = this.options.xOffset==null? 5 : this.options.xOffset
+  this.options.xOffset = this.options.xOffset==null? 5 : this.options.xOffset;
   if (this.options.showText === false)
-    this.options.showText = false
+    this.options.showText = false;
   else
-    this.options.showText = true
+    this.options.showText = true;
 
   this.on("attach", function() {
     if (self.options.data) {
-      self.setData(self.options.data)
+      self.setData(self.options.data);
     }
-  })
+  });
 }
 
 Bar.prototype = Object.create(Canvas.prototype);
 
 Bar.prototype.calcSize = function() {
-  this.canvasSize = {width: this.width-2, height: this.height}
-}
+  this.canvasSize = {width: this.width-2, height: this.height};
+};
 
 Bar.prototype.setData = function(bar) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for bar charts must be called after the chart has been added to the screen via screen.append()"
+    throw "error: canvas context does not exist. setData() for bar charts must be called after the chart has been added to the screen via screen.append()";
   }
 
-  this.clear()
+  this.clear();
 
   var c = this.ctx;
   var max = Math.max.apply(Math, bar.data);
-  max = Math.max(max, this.options.maxHeight)
+  max = Math.max(max, this.options.maxHeight);
   var x = this.options.xOffset;
   var barY = this.canvasSize.height - 5;
 
@@ -56,20 +56,20 @@ Bar.prototype.setData = function(bar) {
     var h = Math.round(barY * (bar.data[i] / max));
 
     if (bar.data[i] > 0) {
-      c.strokeStyle = 'blue'
+      c.strokeStyle = 'blue';
       if (this.options.barBgColor)
         c.strokeStyle = this.options.barBgColor;
       c.fillRect(x, barY - h + 1, this.options.barWidth, h);
     } else {
-      c.strokeStyle = 'normal'
+      c.strokeStyle = 'normal';
     }
 
-    c.fillStyle = 'white'
+    c.fillStyle = 'white';
     if (this.options.barFgColor)
       c.fillStyle = this.options.barFgColor;
     if (this.options.showText)
       c.fillText(bar.data[i].toString(), x + 1, this.canvasSize.height - 4);
-    c.strokeStyle = 'normal'
+    c.strokeStyle = 'normal';
     c.fillStyle = 'white';
     if (this.options.labelColor)
       c.fillStyle = this.options.labelColor;
@@ -78,7 +78,7 @@ Bar.prototype.setData = function(bar) {
 
     x += this.options.barSpacing;
   }
-}
+};
 
 Bar.prototype.getOptionsPrototype = function() {
   return  {  barWidth: 1
@@ -87,9 +87,9 @@ Bar.prototype.getOptionsPrototype = function() {
     ,  maxHeight: 1
     ,  data: { titles: ['s']
       , data: [1]}
-  }
-}
+  };
+};
 
 Bar.prototype.type = 'bar';
 
-module.exports = Bar
+module.exports = Bar;

--- a/lib/widget/charts/line.js
+++ b/lib/widget/charts/line.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('../canvas')
@@ -12,9 +12,9 @@ function Line(options) {
 
   options.showNthLabel = options.showNthLabel || 1;
   options.style = options.style || {};
-  options.style.line = options.style.line || "yellow";
-  options.style.text = options.style.text || "green";
-  options.style.baseline = options.style.baseline || "black";
+  options.style.line = options.style.line || 'yellow';
+  options.style.text = options.style.text || 'green';
+  options.style.baseline = options.style.baseline || 'black';
   options.xLabelPadding = options.xLabelPadding || 5;
   options.xPadding = options.xPadding || 10;
   options.numYLabels = options.numYLabels || 5;
@@ -36,7 +36,7 @@ Line.prototype.type = 'line';
 Line.prototype.setData = function(data) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()";
+    throw 'error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()';
   }
 
   //compatability with older api
@@ -60,7 +60,7 @@ Line.prototype.setData = function(data) {
       width: legendWidth,
       left: self.width-legendWidth-3,
       content: '',
-      fg: "green",
+      fg: 'green',
       tags: true,
       border: {
         type: 'line',
@@ -72,7 +72,7 @@ Line.prototype.setData = function(data) {
       screen: self.screen
     });
 
-    var legandText = "";
+    var legandText = '';
     var maxChars = legendWidth-2;
     for (let i=0; i<data.length; i++) {
       var style = data[i].style || {};

--- a/lib/widget/charts/line.js
+++ b/lib/widget/charts/line.js
@@ -3,24 +3,24 @@ var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('../canvas')
   , utils = require('../../utils.js')
-  , _ = require('lodash')
+  , _ = require('lodash');
 
 function Line(options) {
   if (!(this instanceof Node)) {
     return new Line(options);
   }
 
-  options.showNthLabel = options.showNthLabel || 1
-  options.style = options.style || {}
-  options.style.line = options.style.line || "yellow"
-  options.style.text = options.style.text || "green"
-  options.style.baseline = options.style.baseline || "black"
-  options.xLabelPadding = options.xLabelPadding || 5
-  options.xPadding = options.xPadding || 10
-  options.numYLabels = options.numYLabels || 5
-  options.legend = options.legend || {}
-  options.wholeNumbersOnly = options.wholeNumbersOnly || false
-  options.minY = options.minY || 0
+  options.showNthLabel = options.showNthLabel || 1;
+  options.style = options.style || {};
+  options.style.line = options.style.line || "yellow";
+  options.style.text = options.style.text || "green";
+  options.style.baseline = options.style.baseline || "black";
+  options.xLabelPadding = options.xLabelPadding || 5;
+  options.xPadding = options.xPadding || 10;
+  options.numYLabels = options.numYLabels || 5;
+  options.legend = options.legend || {};
+  options.wholeNumbersOnly = options.wholeNumbersOnly || false;
+  options.minY = options.minY || 0;
 
   Canvas.call(this, options);
 }
@@ -28,32 +28,32 @@ function Line(options) {
 Line.prototype = Object.create(Canvas.prototype);
 
 Line.prototype.calcSize = function() {
-  this.canvasSize = {width: this.width*2-12, height: this.height*4-8}
-}
+  this.canvasSize = {width: this.width*2-12, height: this.height*4-8};
+};
 
 Line.prototype.type = 'line';
 
 Line.prototype.setData = function(data) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()"
+    throw "error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()";
   }
 
   //compatability with older api
-  if (!Array.isArray(data)) data = [data]
+  if (!Array.isArray(data)) data = [data];
 
-  var self = this
-  var xLabelPadding = this.options.xLabelPadding
-  var yLabelPadding = 3
-  var xPadding = this.options.xPadding
-  var yPadding = 11
-  var c = this.ctx
-  var labels = data[0].x
+  var self = this;
+  var xLabelPadding = this.options.xLabelPadding;
+  var yLabelPadding = 3;
+  var xPadding = this.options.xPadding;
+  var yPadding = 11;
+  var c = this.ctx;
+  var labels = data[0].x;
 
   function addLegend() {
-    if (!self.options.showLegend) return
-    if (self.legend) self.remove(self.legend)
-    var legendWidth = self.options.legend.width || 15
+    if (!self.options.showLegend) return;
+    if (self.legend) self.remove(self.legend);
+    var legendWidth = self.options.legend.width || 15;
     self.legend = blessed.box({
       height: data.length+2,
       top: 1,
@@ -72,15 +72,15 @@ Line.prototype.setData = function(data) {
       screen: self.screen
     });
 
-    var legandText = ""
-    var maxChars = legendWidth-2
+    var legandText = "";
+    var maxChars = legendWidth-2;
     for (let i=0; i<data.length; i++) {
-      var style = data[i].style || {}
-      var color = utils.getColorCode(style.line || self.options.style.line)
-      legandText += '{'+color+'-fg}'+ data[i].title.substring(0, maxChars)+'{/'+color+'-fg}\r\n'
+      var style = data[i].style || {};
+      var color = utils.getColorCode(style.line || self.options.style.line);
+      legandText += '{'+color+'-fg}'+ data[i].title.substring(0, maxChars)+'{/'+color+'-fg}\r\n';
     }
-    self.legend.setContent(legandText)
-    self.append(self.legend)
+    self.legend.setContent(legandText);
+    self.append(self.legend);
   }
 
   //iteratee for lodash _.max
@@ -104,18 +104,18 @@ Line.prototype.setData = function(data) {
   }
 
   function formatYLabel(value, max, min, numLabels, wholeNumbersOnly, abbreviate) {
-    var fixed = (((max - min) / numLabels) < 1 && value!=0 && !wholeNumbersOnly) ? 2 : 0
-    var res = value.toFixed(fixed)
-    return abbreviate?utils.abbreviateNumber(res):res
+    var fixed = (((max - min) / numLabels) < 1 && value!=0 && !wholeNumbersOnly) ? 2 : 0;
+    var res = value.toFixed(fixed);
+    return abbreviate?utils.abbreviateNumber(res):res;
   }
 
   function getMaxXLabelPadding(numLabels, wholeNumbersOnly, abbreviate, min) {
-    var max = getMaxY()
+    var max = getMaxY();
 
     return formatYLabel(max, max, min, numLabels, wholeNumbersOnly, abbreviate).length * 2;
   }
 
-  var maxPadding = getMaxXLabelPadding(this.options.numYLabels, this.options.wholeNumbersOnly, this.options.abbreviate, this.options.minY)
+  var maxPadding = getMaxXLabelPadding(this.options.numYLabels, this.options.wholeNumbersOnly, this.options.abbreviate, this.options.minY);
   if (xLabelPadding < maxPadding) {
     xLabelPadding = maxPadding;
   }
@@ -144,17 +144,17 @@ Line.prototype.setData = function(data) {
 
   function getYPixel(val, minY) {
     var res = self.canvasSize.height - yPadding - (((self.canvasSize.height - yPadding) / (getMaxY()-minY)) * (val-minY));
-    res-=2 //to separate the baseline and the data line to separate chars so canvas will show separate colors
-    return res
+    res-=2; //to separate the baseline and the data line to separate chars so canvas will show separate colors
+    return res;
   }
 
   // Draw the line graph
   function drawLine(values, style, minY) {
-    style = style || {}
-    var color = self.options.style.line
-    c.strokeStyle = style.line || color
+    style = style || {};
+    var color = self.options.style.line;
+    c.strokeStyle = style.line || color;
 
-    c.moveTo(0, 0)
+    c.moveTo(0, 0);
     c.beginPath();
     c.lineTo(getXPixel(0), getYPixel(values[0], minY));
 
@@ -165,35 +165,35 @@ Line.prototype.setData = function(data) {
     c.stroke();
   }
 
-  addLegend()
+  addLegend();
 
-  c.fillStyle = this.options.style.text
+  c.fillStyle = this.options.style.text;
 
   c.clearRect(0, 0, this.canvasSize.width, this.canvasSize.height);
 
 
-  var yLabelIncrement = (getMaxY()-this.options.minY)/this.options.numYLabels
-  if (this.options.wholeNumbersOnly) yLabelIncrement = Math.floor(yLabelIncrement)
+  var yLabelIncrement = (getMaxY()-this.options.minY)/this.options.numYLabels;
+  if (this.options.wholeNumbersOnly) yLabelIncrement = Math.floor(yLabelIncrement);
   //if (getMaxY()>=10) {
   //  yLabelIncrement = yLabelIncrement + (10 - yLabelIncrement % 10)
   //}
 
   //yLabelIncrement = Math.max(yLabelIncrement, 1) // should not be zero
 
-  if (yLabelIncrement==0) yLabelIncrement = 1
+  if (yLabelIncrement==0) yLabelIncrement = 1;
 
   // Draw the Y value texts
-  var maxY = getMaxY()
+  var maxY = getMaxY();
   for(var i = this.options.minY; i < maxY; i += yLabelIncrement) {
     c.fillText(formatYLabel(i, maxY, this.options.minY, this.options.numYLabels, this.options.wholeNumbersOnly, this.options.abbreviate), xPadding - xLabelPadding, getYPixel(i, this.options.minY));
   }
 
   for (var h=0; h<data.length; h++) {
-    drawLine(data[h].y, data[h].style, this.options.minY)
+    drawLine(data[h].y, data[h].style, this.options.minY);
   }
 
 
-  c.strokeStyle = this.options.style.baseline
+  c.strokeStyle = this.options.style.baseline;
 
   // Draw the axises
   c.beginPath();
@@ -219,7 +219,7 @@ Line.prototype.setData = function(data) {
     }
   }
 
-}
+};
 
 Line.prototype.getOptionsPrototype = function() {
   return { width: 80
@@ -248,7 +248,7 @@ Line.prototype.getOptionsPrototype = function() {
       style: {line: 'blue'}
     }]
 
-  }
-}
+  };
+};
 
-module.exports = Line
+module.exports = Line;

--- a/lib/widget/charts/stacked-bar.js
+++ b/lib/widget/charts/stacked-bar.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('../canvas')
@@ -31,7 +31,7 @@ function StackedBar(options) {
   else
     this.options.showLegend = true;
 
-  this.on("attach", function() {
+  this.on('attach', function() {
     if (self.options.data) {
       self.setData(self.options.data);
     }
@@ -58,7 +58,7 @@ StackedBar.prototype.getSummedBars = function(bars) {
 StackedBar.prototype.setData = function(bars) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for bar charts must be called after the chart has been added to the screen via screen.append()";
+    throw 'error: canvas context does not exist. setData() for bar charts must be called after the chart has been added to the screen via screen.append()';
   }
 
   this.clear();
@@ -190,7 +190,7 @@ StackedBar.prototype.addLegend = function(bars, x) {
     width: legendWidth,
     left: x,
     content: '',
-    fg: "green",
+    fg: 'green',
     tags: true,
     border: {
       type: 'line',
@@ -202,7 +202,7 @@ StackedBar.prototype.addLegend = function(bars, x) {
     screen: self.screen
   });
 
-  var legandText = "";
+  var legandText = '';
   var maxChars = legendWidth-2;
   for (var i=0; i<bars.stackedCategory.length; i++) {
     var color = utils.getColorCode(self.options.barBgColor[i]);

--- a/lib/widget/charts/stacked-bar.js
+++ b/lib/widget/charts/stacked-bar.js
@@ -2,79 +2,79 @@
 var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('../canvas')
-  , utils = require('../../utils.js')
+  , utils = require('../../utils.js');
 
 function StackedBar(options) {
   if (!(this instanceof Node)) {
     return new StackedBar(options);
   }
 
-  var self = this
+  var self = this;
   Canvas.call(this, options, require('ansi-term'));
 
-  this.options.barWidth = this.options.barWidth || 6
-  this.options.barSpacing = this.options.barSpacing || 9
+  this.options.barWidth = this.options.barWidth || 6;
+  this.options.barSpacing = this.options.barSpacing || 9;
 
   if ((this.options.barSpacing - this.options.barWidth) < 3) {
     this.options.barSpacing = this.options.barWidth + 3;
   }
 
-  this.options.xOffset = this.options.xOffset==null? 5 : this.options.xOffset
+  this.options.xOffset = this.options.xOffset==null? 5 : this.options.xOffset;
   if (this.options.showText === false)
-    this.options.showText = false
+    this.options.showText = false;
   else
-    this.options.showText = true
+    this.options.showText = true;
 
-  this.options.legend = this.options.legend || {}
+  this.options.legend = this.options.legend || {};
   if (this.options.showLegend === false)
-    this.options.showLegend = false
+    this.options.showLegend = false;
   else
-    this.options.showLegend = true
+    this.options.showLegend = true;
 
   this.on("attach", function() {
     if (self.options.data) {
-      self.setData(self.options.data)
+      self.setData(self.options.data);
     }
-  })
+  });
 }
 
 StackedBar.prototype = Object.create(Canvas.prototype);
 
 StackedBar.prototype.calcSize = function() {
-  this.canvasSize = {width: this.width-2, height: this.height}
-}
+  this.canvasSize = {width: this.width-2, height: this.height};
+};
 
 StackedBar.prototype.getSummedBars = function(bars) {
-  var res = []
+  var res = [];
   bars.forEach(function(stackedValues) {
     var sum = stackedValues.reduce(function(a,b) {
-      return a + b
-    } , 0)
-    res.push(sum)
-  })
-  return res
-}
+      return a + b;
+    } , 0);
+    res.push(sum);
+  });
+  return res;
+};
 
 StackedBar.prototype.setData = function(bars) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for bar charts must be called after the chart has been added to the screen via screen.append()"
+    throw "error: canvas context does not exist. setData() for bar charts must be called after the chart has been added to the screen via screen.append()";
   }
 
-  this.clear()
+  this.clear();
 
-  var summedBars = this.getSummedBars(bars.data)
-  var maxBarValue = Math.max.apply(Math, summedBars)
+  var summedBars = this.getSummedBars(bars.data);
+  var maxBarValue = Math.max.apply(Math, summedBars);
   if (this.options.maxValue)
-    maxBarValue = Math.max(maxBarValue, this.options.maxValue)
+    maxBarValue = Math.max(maxBarValue, this.options.maxValue);
   var x = this.options.xOffset;
   for (var i = 0; i < bars.data.length; i++) {
-    this.renderBar(x, bars.data[i], summedBars[i], maxBarValue, bars.barCategory[i])
+    this.renderBar(x, bars.data[i], summedBars[i], maxBarValue, bars.barCategory[i]);
     x += this.options.barSpacing;
   }
 
-  this.addLegend(bars, x)
-}
+  this.addLegend(bars, x);
+};
 
 StackedBar.prototype.renderBar = function(x, bar, curBarSummedValue, maxBarValue, category) {
 /*
@@ -88,11 +88,11 @@ StackedBar.prototype.renderBar = function(x, bar, curBarSummedValue, maxBarValue
   return
 */
   //first line is for label
-  const BUFFER_FROM_TOP = 2
-  const BUFFER_FROM_BOTTOM = (this.options.border ? 2 : 0) + (this.options.showText ? 1 : 0)
+  const BUFFER_FROM_TOP = 2;
+  const BUFFER_FROM_BOTTOM = (this.options.border ? 2 : 0) + (this.options.showText ? 1 : 0);
 
-  var c = this.ctx
-  c.strokeStyle = 'normal'
+  var c = this.ctx;
+  c.strokeStyle = 'normal';
   c.fillStyle = 'white';
   if (this.options.labelColor)
     c.fillStyle = this.options.labelColor;
@@ -100,12 +100,12 @@ StackedBar.prototype.renderBar = function(x, bar, curBarSummedValue, maxBarValue
     c.fillText(category, x + 1, this.canvasSize.height - BUFFER_FROM_BOTTOM);
   }
 
-  if (curBarSummedValue < 0) return
-  var maxBarHeight = this.canvasSize.height - BUFFER_FROM_TOP - BUFFER_FROM_BOTTOM
-  var currentBarHeight = Math.round(maxBarHeight * (curBarSummedValue / maxBarValue))
+  if (curBarSummedValue < 0) return;
+  var maxBarHeight = this.canvasSize.height - BUFFER_FROM_TOP - BUFFER_FROM_BOTTOM;
+  var currentBarHeight = Math.round(maxBarHeight * (curBarSummedValue / maxBarValue));
   //start painting from bottom of bar, section by section
-  var y = maxBarHeight + BUFFER_FROM_TOP
-  var availableBarHeight = currentBarHeight
+  var y = maxBarHeight + BUFFER_FROM_TOP;
+  var availableBarHeight = currentBarHeight;
   for (var i=0; i < bar.length; i++) {
     var currStackHeight = this.renderBarSection(
       x,
@@ -114,11 +114,11 @@ StackedBar.prototype.renderBar = function(x, bar, curBarSummedValue, maxBarValue
       curBarSummedValue,
       currentBarHeight,
       availableBarHeight,
-      this.options.barBgColor[i])
-    y -= currStackHeight
-    availableBarHeight -= currStackHeight
+      this.options.barBgColor[i]);
+    y -= currStackHeight;
+    availableBarHeight -= currStackHeight;
   }
-}
+};
 
 StackedBar.prototype.renderBarSection = function(
   x,
@@ -128,32 +128,32 @@ StackedBar.prototype.renderBarSection = function(
   currentBarHeight,
   availableBarHeight,
   bg) {
-  var c = this.ctx
+  var c = this.ctx;
 
   var currStackHeight = currentBarHeight <= 0?
     0 :
     Math.min(
       availableBarHeight, //round() can make total stacks excceed curr bar height so we limit it
       Math.round(currentBarHeight * (data / curBarSummedValue))
-    )
+    );
   c.strokeStyle = bg;
 
   if (currStackHeight>0) {
-    var calcY = y - currStackHeight
+    var calcY = y - currStackHeight;
     /*fillRect starts from the point bottom of start point so we compensate*/
-    var calcHeight = Math.max(0, currStackHeight-1)
+    var calcHeight = Math.max(0, currStackHeight-1);
     c.fillRect(
       x,
       calcY,
       this.options.barWidth,
       calcHeight
-    )
+    );
 
-    c.fillStyle = 'white'
+    c.fillStyle = 'white';
     if (this.options.barFgColor)
       c.fillStyle = this.options.barFgColor;
     if (this.options.showText) {
-      var str = utils.abbreviateNumber(data.toString())
+      var str = utils.abbreviateNumber(data.toString());
       c.fillText(
         str,
         Math.floor(x + this.options.barWidth/2 + str.length/2),
@@ -161,8 +161,8 @@ StackedBar.prototype.renderBarSection = function(
     }
   }
 
-  return currStackHeight
-}
+  return currStackHeight;
+};
 
 StackedBar.prototype.getOptionsPrototype = function() {
   return  {  barWidth: 1
@@ -174,16 +174,16 @@ StackedBar.prototype.getOptionsPrototype = function() {
       , stackedCategory: ['s']
       , data: [ [ 1] ]
     }
-  }
-}
+  };
+};
 
 
 
 StackedBar.prototype.addLegend = function(bars, x) {
-  var self = this
-  if (!self.options.showLegend) return
-  if (self.legend) self.remove(self.legend)
-  var legendWidth = self.options.legend.width || 15
+  var self = this;
+  if (!self.options.showLegend) return;
+  if (self.legend) self.remove(self.legend);
+  var legendWidth = self.options.legend.width || 15;
   self.legend = blessed.box({
     height: bars.stackedCategory.length+2,
     top: 1,
@@ -202,16 +202,16 @@ StackedBar.prototype.addLegend = function(bars, x) {
     screen: self.screen
   });
 
-  var legandText = ""
-  var maxChars = legendWidth-2
+  var legandText = "";
+  var maxChars = legendWidth-2;
   for (var i=0; i<bars.stackedCategory.length; i++) {
-    var color = utils.getColorCode(self.options.barBgColor[i])
-    legandText += '{'+color+'-fg}'+ bars.stackedCategory[i].substring(0, maxChars)+'{/'+color+'-fg}\r\n'
+    var color = utils.getColorCode(self.options.barBgColor[i]);
+    legandText += '{'+color+'-fg}'+ bars.stackedCategory[i].substring(0, maxChars)+'{/'+color+'-fg}\r\n';
   }
-  self.legend.setContent(legandText)
-  self.append(self.legend)
-}
+  self.legend.setContent(legandText);
+  self.append(self.legend);
+};
 
 StackedBar.prototype.type = 'bar';
 
-module.exports = StackedBar
+module.exports = StackedBar;

--- a/lib/widget/donut.js
+++ b/lib/widget/donut.js
@@ -9,9 +9,9 @@ function Donut(options) {
   }
 
   options = options || {};
-  this.options = options
-  this.options.stroke = options.stroke || "magenta"
-  this.options.fill = options.fill || "white"
+  this.options = options;
+  this.options.stroke = options.stroke || "magenta";
+  this.options.fill = options.fill || "white";
   this.options.radius = options.radius || 14;
   this.options.arcWidth = options.arcWidth || 4;
   this.options.spacing = options.spacing || 2;
@@ -21,42 +21,42 @@ function Donut(options) {
 
   Canvas.call(this, options);
 
-  var self = this
+  var self = this;
   this.on("attach", function() {
     this.setData(self.options.data);
-  })
+  });
 }
 
 Donut.prototype = Object.create(Canvas.prototype);
 
 Donut.prototype.calcSize = function() {
-  this.canvasSize = {width: Math.round(this.width*2-5), height: this.height*4-12}
+  this.canvasSize = {width: Math.round(this.width*2-5), height: this.height*4-12};
   if (this.canvasSize.width % 2 == 1)
     this.canvasSize.width--;
   if (this.canvasSize.height % 4 != 1)
     this.canvasSize.height += (this.canvasSize.height % 4);
-}
+};
 
 Donut.prototype.type = 'donut';
 
 var cos = Math.cos;
 var sin = Math.sin;
-var pi = 3.141592635
+var pi = 3.141592635;
 Donut.prototype.setData = function(data){
   this.update(data);
-}
+};
 Donut.prototype.update = function(data) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()"
+    throw "error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()";
   }
 
-  var c = this.ctx
+  var c = this.ctx;
   c.save();
   c.translate(0,-this.options.yPadding);
 
-  c.strokeStyle = this.options.stroke
-  c.fillStyle = this.options.fill
+  c.strokeStyle = this.options.stroke;
+  c.fillStyle = this.options.fill;
 
   c.clearRect(0, 0, this.canvasSize.width, this.canvasSize.height);
 
@@ -72,7 +72,7 @@ Donut.prototype.update = function(data) {
         s++;
         continue;
       }
-      var slice = 2 * pi / points
+      var slice = 2 * pi / points;
       c.beginPath();
       var p = parseFloat(percent*360);
       for(var i = 0;i<=points;i++){
@@ -105,7 +105,7 @@ Donut.prototype.update = function(data) {
   }
 
   function makeDonut(stat, which){
-    var left = radius + (spacing * which) + (radius * 2 * (which - 1))
+    var left = radius + (spacing * which) + (radius * 2 * (which - 1));
     var percent = stat.percent;
     if (percent > 1.001){
       percent = parseFloat(percent / 100).toFixed(2);
@@ -131,7 +131,7 @@ Donut.prototype.update = function(data) {
 
   c.restore();
   return;
-}
+};
 
 Donut.prototype.getOptionsPrototype = function() {
   return {
@@ -143,7 +143,7 @@ Donut.prototype.getOptionsPrototype = function() {
       , { color: 'blue', percent: '20', label: 'b'}
       , { color: 'yellow', percent: '80', label: 'c'}
     ]
-  }
-}
+  };
+};
 
-module.exports = Donut
+module.exports = Donut;

--- a/lib/widget/donut.js
+++ b/lib/widget/donut.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('./canvas');
@@ -10,19 +10,19 @@ function Donut(options) {
 
   options = options || {};
   this.options = options;
-  this.options.stroke = options.stroke || "magenta";
-  this.options.fill = options.fill || "white";
+  this.options.stroke = options.stroke || 'magenta';
+  this.options.fill = options.fill || 'white';
   this.options.radius = options.radius || 14;
   this.options.arcWidth = options.arcWidth || 4;
   this.options.spacing = options.spacing || 2;
   this.options.yPadding = options.yPadding || 2;
-  this.options.remainColor = options.remainColor || "black";
+  this.options.remainColor = options.remainColor || 'black';
   this.options.data = options.data || [];
 
   Canvas.call(this, options);
 
   var self = this;
-  this.on("attach", function() {
+  this.on('attach', function() {
     this.setData(self.options.data);
   });
 }
@@ -48,7 +48,7 @@ Donut.prototype.setData = function(data){
 Donut.prototype.update = function(data) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()";
+    throw 'error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()';
   }
 
   var c = this.ctx;
@@ -66,7 +66,7 @@ Donut.prototype.update = function(data) {
   function makeRound(percent, radius, width, cx, cy, color){
     var s = 0;
     var points = 370;
-    c.strokeStyle = color || "green";
+    c.strokeStyle = color || 'green';
     while(s<radius){
       if (s < (radius - width)) {
         s++;
@@ -99,7 +99,7 @@ Donut.prototype.update = function(data) {
   function drawDonut(label, percent, radius, width, cxx, middle, color){
     makeRound(100, radius, width, cxx, middle, remainColor );
     makeRound(percent, radius, width, cxx, middle, color);
-    var ptext = parseFloat(percent*100).toFixed(0) + "%";
+    var ptext = parseFloat(percent*100).toFixed(0) + '%';
     c.fillText(ptext, cxx - Math.round(parseFloat((c.measureText(ptext).width)/2)) + 3, middle);
     c.fillText(label, cxx - Math.round(parseFloat((c.measureText(label).width)/2)) + 3, (middle + radius) + 5);
   }
@@ -111,7 +111,7 @@ Donut.prototype.update = function(data) {
       percent = parseFloat(percent / 100).toFixed(2);
     }
     var label = stat.label;
-    var color = stat.color || "green";
+    var color = stat.color || 'green';
     var cxx = left;
     drawDonut(label, percent, radius, width, cxx, middle, color);
   }
@@ -127,7 +127,7 @@ Donut.prototype.update = function(data) {
 
   this.currentData = data;
 
-  c.strokeStyle = "magenta";
+  c.strokeStyle = 'magenta';
 
   c.restore();
   return;

--- a/lib/widget/gauge-list.js
+++ b/lib/widget/gauge-list.js
@@ -1,106 +1,106 @@
 "use strict";
 var blessed = require('blessed')
   , Node = blessed.Node
-  , Canvas = require('./canvas')
+  , Canvas = require('./canvas');
 
 function GaugeList(options) {
   if (!(this instanceof Node)) {
     return new GaugeList(options);
   }
 
-  var self = this
+  var self = this;
 
   options = options || {};
-  self.options = options
-  self.options.stroke = options.stroke || "magenta"
-  self.options.fill = options.fill || "white"
-  self.options.data = options.data || []
-  self.options.showLabel = options.showLabel !== false
-  self.options.gaugeSpacing = options.gaugeSpacing || 0
-  self.options.gaugeHeight = options.gaugeHeight || 1
+  self.options = options;
+  self.options.stroke = options.stroke || "magenta";
+  self.options.fill = options.fill || "white";
+  self.options.data = options.data || [];
+  self.options.showLabel = options.showLabel !== false;
+  self.options.gaugeSpacing = options.gaugeSpacing || 0;
+  self.options.gaugeHeight = options.gaugeHeight || 1;
 
   Canvas.call(this, options, require('ansi-term'));
 
   this.on("attach", function() {
-    var gauges = this.gauges = self.options.gauges
-    this.setGauges(gauges)
-  })
+    var gauges = this.gauges = self.options.gauges;
+    this.setGauges(gauges);
+  });
 
 }
 
 GaugeList.prototype = Object.create(Canvas.prototype);
 
 GaugeList.prototype.calcSize = function() {
-  this.canvasSize = {width: this.width-2, height: this.height}
-}
+  this.canvasSize = {width: this.width-2, height: this.height};
+};
 
 GaugeList.prototype.type = 'gauge';
 
 GaugeList.prototype.setData = function() {
-}
+};
 
 GaugeList.prototype.setGauges = function(gauges) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()"
+    throw "error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()";
   }
 
-  var c = this.ctx
+  var c = this.ctx;
   c.clearRect(0, 0, this.canvasSize.width, this.canvasSize.height);
 
   for (var i=0; i<gauges.length; i++) {
-    this.setSingleGauge(gauges[i], i)
+    this.setSingleGauge(gauges[i], i);
   }
 
-}
+};
 
 GaugeList.prototype.setSingleGauge = function(gauge, offset) {
 
   var colors = ['green','magenta','cyan','red','blue'];
-  var stack = gauge.stack
+  var stack = gauge.stack;
 
-  var c = this.ctx
+  var c = this.ctx;
   var leftStart = 3;
   var textLeft = 5;
 
-  c.strokeStyle='normal'
-  c.fillStyle='white'
-  c.fillText(offset.toString(), 0, offset*(this.options.gaugeHeight+this.options.gaugeSpacing))
+  c.strokeStyle='normal';
+  c.fillStyle='white';
+  c.fillText(offset.toString(), 0, offset*(this.options.gaugeHeight+this.options.gaugeSpacing));
 
   for (var i = 0; i < stack.length; i++) {
-    var currentStack = stack[i]
+    var currentStack = stack[i];
 
-    var percent
+    var percent;
     if (typeof(currentStack) == typeof({})){
-      percent = currentStack.percent
+      percent = currentStack.percent;
     } else {
-      percent = currentStack
+      percent = currentStack;
     }
 
-    c.strokeStyle = currentStack.stroke || colors[(i%colors.length)] // use specified or choose from the array of colors
-    c.fillStyle = this.options.fill//'white'
+    c.strokeStyle = currentStack.stroke || colors[(i%colors.length)]; // use specified or choose from the array of colors
+    c.fillStyle = this.options.fill;//'white'
 
     textLeft = 5;
 
-    var width = percent/100*(this.canvasSize.width-5)
+    var width = percent/100*(this.canvasSize.width-5);
 
-    c.fillRect(leftStart, offset*(this.options.gaugeHeight+this.options.gaugeSpacing), width, this.options.gaugeHeight-1)
+    c.fillRect(leftStart, offset*(this.options.gaugeHeight+this.options.gaugeSpacing), width, this.options.gaugeHeight-1);
 
     textLeft = (width / 2) - 1;
     // if (textLeft)
-    var textX = leftStart+textLeft
+    var textX = leftStart+textLeft;
 
     if ((leftStart+width)<textX) {
-      c.strokeStyle = 'normal'
+      c.strokeStyle = 'normal';
     }
-    if (gauge.showLabel) c.fillText(percent+"%", textX, 3)
+    if (gauge.showLabel) c.fillText(percent+"%", textX, 3);
 
     leftStart += width;
   }
-}
+};
 
 GaugeList.prototype.getOptionsPrototype = function() {
-  return {percent: 10}
-}
+  return {percent: 10};
+};
 
-module.exports = GaugeList
+module.exports = GaugeList;

--- a/lib/widget/gauge-list.js
+++ b/lib/widget/gauge-list.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('./canvas');
@@ -12,8 +12,8 @@ function GaugeList(options) {
 
   options = options || {};
   self.options = options;
-  self.options.stroke = options.stroke || "magenta";
-  self.options.fill = options.fill || "white";
+  self.options.stroke = options.stroke || 'magenta';
+  self.options.fill = options.fill || 'white';
   self.options.data = options.data || [];
   self.options.showLabel = options.showLabel !== false;
   self.options.gaugeSpacing = options.gaugeSpacing || 0;
@@ -21,7 +21,7 @@ function GaugeList(options) {
 
   Canvas.call(this, options, require('ansi-term'));
 
-  this.on("attach", function() {
+  this.on('attach', function() {
     var gauges = this.gauges = self.options.gauges;
     this.setGauges(gauges);
   });
@@ -42,7 +42,7 @@ GaugeList.prototype.setData = function() {
 GaugeList.prototype.setGauges = function(gauges) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()";
+    throw 'error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()';
   }
 
   var c = this.ctx;
@@ -93,7 +93,7 @@ GaugeList.prototype.setSingleGauge = function(gauge, offset) {
     if ((leftStart+width)<textX) {
       c.strokeStyle = 'normal';
     }
-    if (gauge.showLabel) c.fillText(percent+"%", textX, 3);
+    if (gauge.showLabel) c.fillText(percent+'%', textX, 3);
 
     leftStart += width;
   }

--- a/lib/widget/gauge.js
+++ b/lib/widget/gauge.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('./canvas');
@@ -12,14 +12,14 @@ function Gauge(options) {
 
   options = options || {};
   self.options = options;
-  self.options.stroke = options.stroke || "magenta";
-  self.options.fill = options.fill || "white";
+  self.options.stroke = options.stroke || 'magenta';
+  self.options.fill = options.fill || 'white';
   self.options.data = options.data || [];
   self.options.showLabel = options.showLabel !== false;
 
   Canvas.call(this, options, require('ansi-term'));
 
-  this.on("attach", function() {
+  this.on('attach', function() {
     if (self.options.stack) {
       var stack = this.stack = self.options.stack;
       this.setStack(stack);
@@ -49,7 +49,7 @@ Gauge.prototype.setData = function(data){
 Gauge.prototype.setPercent = function(percent) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()";
+    throw 'error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()';
   }
 
   var c = this.ctx;
@@ -69,14 +69,14 @@ Gauge.prototype.setPercent = function(percent) {
     c.strokeStyle = 'normal';
   }
 
-  if (this.options.showLabel) c.fillText(Math.round(percent)+"%", textX, 3);
+  if (this.options.showLabel) c.fillText(Math.round(percent)+'%', textX, 3);
 };
 
 Gauge.prototype.setStack = function(stack) {
   var colors = ['green','magenta','cyan','red','blue'];
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()";
+    throw 'error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()';
   }
 
   var c = this.ctx;
@@ -111,7 +111,7 @@ Gauge.prototype.setStack = function(stack) {
     if ((leftStart+width)<textX) {
       c.strokeStyle = 'normal';
     }
-    if (this.options.showLabel) c.fillText(percent+"%", textX, 3);
+    if (this.options.showLabel) c.fillText(percent+'%', textX, 3);
 
     leftStart += width;
   }

--- a/lib/widget/gauge.js
+++ b/lib/widget/gauge.js
@@ -1,40 +1,40 @@
 "use strict";
 var blessed = require('blessed')
   , Node = blessed.Node
-  , Canvas = require('./canvas')
+  , Canvas = require('./canvas');
 
 function Gauge(options) {
   if (!(this instanceof Node)) {
     return new Gauge(options);
   }
 
-  var self = this
+  var self = this;
 
   options = options || {};
-  self.options = options
-  self.options.stroke = options.stroke || "magenta"
-  self.options.fill = options.fill || "white"
-  self.options.data = options.data || []
-  self.options.showLabel = options.showLabel !== false
+  self.options = options;
+  self.options.stroke = options.stroke || "magenta";
+  self.options.fill = options.fill || "white";
+  self.options.data = options.data || [];
+  self.options.showLabel = options.showLabel !== false;
 
   Canvas.call(this, options, require('ansi-term'));
 
   this.on("attach", function() {
     if (self.options.stack) {
       var stack = this.stack = self.options.stack;
-      this.setStack(stack)
+      this.setStack(stack);
     } else {
       var percent = this.percent = self.options.percent || 0;
-      this.setData(percent)
+      this.setData(percent);
     }
-  })
+  });
 }
 
 Gauge.prototype = Object.create(Canvas.prototype);
 
 Gauge.prototype.calcSize = function() {
-  this.canvasSize = {width: this.width-2, height: this.height}
-}
+  this.canvasSize = {width: this.width-2, height: this.height};
+};
 
 Gauge.prototype.type = 'gauge';
 
@@ -44,82 +44,82 @@ Gauge.prototype.setData = function(data){
   } else if(typeof(data) == typeof(1)) {
     this.setPercent(data);
   }
-}
+};
 
 Gauge.prototype.setPercent = function(percent) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()"
+    throw "error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()";
   }
 
-  var c = this.ctx
+  var c = this.ctx;
 
-  c.strokeStyle = this.options.stroke//'magenta'
-  c.fillStyle = this.options.fill//'white'
+  c.strokeStyle = this.options.stroke;//'magenta'
+  c.fillStyle = this.options.fill;//'white'
 
   c.clearRect(0, 0, this.canvasSize.width, this.canvasSize.height);
   if (percent < 1.001){
     percent = percent * 100;
   }
-  var width = percent/100*(this.canvasSize.width-3)
-  c.fillRect(1, 2, width, 2)
+  var width = percent/100*(this.canvasSize.width-3);
+  c.fillRect(1, 2, width, 2);
 
-  var textX = 7
+  var textX = 7;
   if (width<textX) {
-    c.strokeStyle = 'normal'
+    c.strokeStyle = 'normal';
   }
 
-  if (this.options.showLabel) c.fillText(Math.round(percent)+"%", textX, 3)
-}
+  if (this.options.showLabel) c.fillText(Math.round(percent)+"%", textX, 3);
+};
 
 Gauge.prototype.setStack = function(stack) {
   var colors = ['green','magenta','cyan','red','blue'];
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()"
+    throw "error: canvas context does not exist. setData() for gauges must be called after the gauge has been added to the screen via screen.append()";
   }
 
-  var c = this.ctx
+  var c = this.ctx;
   var leftStart = 1;
   var textLeft = 5;
   c.clearRect(0, 0, this.canvasSize.width, this.canvasSize.height);
 
   for (var i = 0; i < stack.length; i++) {
-    var currentStack = stack[i]
+    var currentStack = stack[i];
 
-    let percent
+    let percent;
     if (typeof(currentStack) == typeof({}))
-      percent = currentStack.percent
+      percent = currentStack.percent;
     else
-      percent = currentStack
+      percent = currentStack;
 
-    c.strokeStyle = currentStack.stroke || colors[(i%colors.length)] // use specified or choose from the array of colors
-    c.fillStyle = this.options.fill//'white'
+    c.strokeStyle = currentStack.stroke || colors[(i%colors.length)]; // use specified or choose from the array of colors
+    c.fillStyle = this.options.fill;//'white'
 
     textLeft = 5;
     if (percent < 1.001){
       percent = percent * 100;
     }
-    var width = percent/100*(this.canvasSize.width-3)
+    var width = percent/100*(this.canvasSize.width-3);
 
-    c.fillRect(leftStart, 2, width, 2)
+    c.fillRect(leftStart, 2, width, 2);
 
     textLeft = (width / 2) - 1;
     // if (textLeft)
-    var textX = leftStart+textLeft
+    var textX = leftStart+textLeft;
 
     if ((leftStart+width)<textX) {
-      c.strokeStyle = 'normal'
+      c.strokeStyle = 'normal';
     }
-    if (this.options.showLabel) c.fillText(percent+"%", textX, 3)
+    if (this.options.showLabel) c.fillText(percent+"%", textX, 3);
 
     leftStart += width;
   }
-}
+};
 
 Gauge.prototype.getOptionsPrototype = function() {
-  return {percent: 10}
-}
+  return {percent: 10};
+};
 
 
-module.exports = Gauge
+module.exports = Gauge;

--- a/lib/widget/lcd.js
+++ b/lib/widget/lcd.js
@@ -1,16 +1,16 @@
 "use strict";
 var blessed = require('blessed')
   , Node = blessed.Node
-  , Canvas = require('./canvas')
+  , Canvas = require('./canvas');
 
 function LCD(options) {
   if (!(this instanceof Node)) {
     return new LCD(options);
   }
-  var self = this
+  var self = this;
 
   options = options || {};
-  self.options = options
+  self.options = options;
 
   //these options need to be modified epending on the resulting positioning/size
   self.options.segmentWidth = options.segmentWidth || 0.06; // how wide are the segments in % so 50% = 0.5
@@ -31,60 +31,60 @@ function LCD(options) {
   this.segment16 = null;
 
   this.on("attach", function() {
-    var display = self.options.display || 1234
+    var display = self.options.display || 1234;
     if (!this.segment16)
       this.segment16 = new SixteenSegment(this.options.elements, this.ctx, this.canvasSize.width, this.canvasSize.height, 0, 0, this.options);
 
     this.setDisplay(display);
-  })
+  });
 }
 
 LCD.prototype = Object.create(Canvas.prototype);
 
 LCD.prototype.calcSize = function() {
-  this.canvasSize = {width: this.width*2-8, height: (this.height*4)-12}
-}
+  this.canvasSize = {width: this.width*2-8, height: (this.height*4)-12};
+};
 
 LCD.prototype.type = 'lcd';
 LCD.prototype.increaseWidth = function(){
   if (this.segment16){
     this.segment16.SegmentWidth+=0.01;
   }
-}
+};
 LCD.prototype.decreaseWidth = function(){
   if (this.segment16){
     this.segment16.SegmentWidth-=0.01;
   }
-}
+};
 LCD.prototype.increaseInterval = function(){
   if (this.segment16){
     this.segment16.SegmentInterval+=0.01;
   }
-}
+};
 LCD.prototype.decreaseInterval = function(){
   if (this.segment16){
     this.segment16.SegmentInterval-=0.01;
   }
-}
+};
 LCD.prototype.increaseStroke = function(){
   if (this.segment16){
     this.segment16.StrokeWidth+=0.05;
   }
-}
+};
 LCD.prototype.decreaseStroke = function(){
   if (this.segment16){
     this.segment16.StrokeWidth-=0.05;
   }
-}
+};
 LCD.prototype.setOptions = function(options){
   if (this.segment16){
-    this.segment16.setOptions(options)
+    this.segment16.setOptions(options);
   }
-}
+};
 
 LCD.prototype.setData = function(data){
   this.setDisplay(data.toString());
-}
+};
 
 LCD.prototype.getOptionsPrototype = function() {
   return {
@@ -96,19 +96,19 @@ LCD.prototype.getOptionsPrototype = function() {
     display: 3210,
     elementSpacing: 4,
     elementPadding: 2
-  }
-}
+  };
+};
 
 LCD.prototype.setDisplay = function(display) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()"
+    throw "error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()";
   }
 
   this.ctx.clearRect(0, 0, this.canvasSize.width, this.canvasSize.height);
 
   this.segment16.DisplayText(display);
-}
+};
 
 function ElementArray(count) {
   this.SetCount = SetCount;
@@ -166,8 +166,8 @@ function ElementArray(count) {
 function SixteenSegment(count, canvas, width, height, x, y, options){
   this.ElementArray = new ElementArray(count);
 
-  this.SegmentWidth = options.segmentWidth//(this.ElementWidth * 0.0015) * 5 //0.1;           // Width of segments (% of Element Width)
-  this.SegmentInterval = options.segmentInterval//(this.ElementWidth * 0.0015) * 10 // 0.20;        // Spacing between segments (% of Element Width)
+  this.SegmentWidth = options.segmentWidth;//(this.ElementWidth * 0.0015) * 5 //0.1;           // Width of segments (% of Element Width)
+  this.SegmentInterval = options.segmentInterval;//(this.ElementWidth * 0.0015) * 10 // 0.20;        // Spacing between segments (% of Element Width)
   this.BevelWidth = 0.01;             // Size of corner bevel (% of Element Width)
   this.SideBevelEnabled = true;      // Should the sides be beveled
   this.StrokeLight = options.color;       // Color of an on segment outline
@@ -448,4 +448,4 @@ var CharacterMasks = (function() {
   };
 }());
 
-module.exports = LCD
+module.exports = LCD;

--- a/lib/widget/lcd.js
+++ b/lib/widget/lcd.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('./canvas');
@@ -24,13 +24,13 @@ function LCD(options) {
   self.options.elementPadding = options.padding || 2; // how far away from the edges to put the elements
 
   //coloring
-  self.options.color = options.color || "white";
+  self.options.color = options.color || 'white';
 
   Canvas.call(this, options);
 
   this.segment16 = null;
 
-  this.on("attach", function() {
+  this.on('attach', function() {
     var display = self.options.display || 1234;
     if (!this.segment16)
       this.segment16 = new SixteenSegment(this.options.elements, this.ctx, this.canvasSize.width, this.canvasSize.height, 0, 0, this.options);
@@ -88,7 +88,7 @@ LCD.prototype.setData = function(data){
 
 LCD.prototype.getOptionsPrototype = function() {
   return {
-    label: "LCD Test",
+    label: 'LCD Test',
     segmentWidth: 0.06,
     segmentInterval: 0.11,
     strokeWidth: 0.1,
@@ -102,7 +102,7 @@ LCD.prototype.getOptionsPrototype = function() {
 LCD.prototype.setDisplay = function(display) {
 
   if (!this.ctx) {
-    throw "error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()";
+    throw 'error: canvas context does not exist. setData() for line charts must be called after the chart has been added to the screen via screen.append()';
   }
 
   this.ctx.clearRect(0, 0, this.canvasSize.width, this.canvasSize.height);
@@ -121,7 +121,7 @@ function ElementArray(count) {
   function SetCount(count) {
     var c = parseInt(count, 10);
     if (isNaN(c)) {
-      throw "Invalid element count: " + count;
+      throw 'Invalid element count: ' + count;
     }
     this.Elements = [c];
     for (var i = 0; i < c; i++) {
@@ -132,7 +132,7 @@ function ElementArray(count) {
   function SetText(value, charMaps) {
     // Get the string of the value passed in
     if (value === null) {
-      value = "";
+      value = '';
     }
     value = value.toString();
 
@@ -181,9 +181,9 @@ function SixteenSegment(count, canvas, width, height, x, y, options){
 
   // console.error("w %s h %s", this.ElementWidth, this.ElementHeight);
 
-  this.FillLight = "red";           // Color of an on segment
-  this.FillDark = "cyan";             // Color of an off segment
-  this.StrokeDark = "black";          // Color of an off segment outline
+  this.FillLight = 'red';           // Color of an on segment
+  this.FillDark = 'cyan';             // Color of an off segment
+  this.StrokeDark = 'black';          // Color of an off segment outline
 
   this.X = 0;
   this.Y = 0;

--- a/lib/widget/log.js
+++ b/lib/widget/log.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , List = blessed.List;

--- a/lib/widget/log.js
+++ b/lib/widget/log.js
@@ -1,7 +1,7 @@
 "use strict";
 var blessed = require('blessed')
   , Node = blessed.Node
-  , List = blessed.List
+  , List = blessed.List;
 
 function Log(options) {
   if (!(this instanceof Node)) {
@@ -10,24 +10,24 @@ function Log(options) {
 
   options = options || {};
   options.bufferLength = options.bufferLength || 30;
-  this.options = options
+  this.options = options;
   List.call(this, options);
 
-  this.logLines = []
-  this.interactive = false
+  this.logLines = [];
+  this.interactive = false;
 }
 
 Log.prototype = Object.create(List.prototype);
 
 Log.prototype.log = function(str) {
-  this.logLines.push(str)
+  this.logLines.push(str);
   if (this.logLines.length>this.options.bufferLength) {
-    this.logLines.shift()
+    this.logLines.shift();
   }
-  this.setItems(this.logLines)
-  this.scrollTo(this.logLines.length)
-}
+  this.setItems(this.logLines);
+  this.scrollTo(this.logLines.length);
+};
 
 Log.prototype.type = 'log';
 
-module.exports = Log
+module.exports = Log;

--- a/lib/widget/map.js
+++ b/lib/widget/map.js
@@ -2,10 +2,10 @@
 var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('./canvas')
-  , InnerMap = require('map-canvas')
+  , InnerMap = require('map-canvas');
 
 function Map(options) {
-  var self = this
+  var self = this;
 
   if (!(this instanceof Node)) {
     return new Map(options);
@@ -15,7 +15,7 @@ function Map(options) {
 
   this.on("attach", function() {
 
-    options.style = options.style || {}
+    options.style = options.style || {};
 
     var opts = { excludeAntartica: (options.excludeAntarctica === undefined) ? true : options.excludeAntarctica
       , disableBackground: (options.disableBackground === undefined) ? true : options.disableBackground
@@ -24,46 +24,46 @@ function Map(options) {
       , disableFill: (options.disableFill === undefined) ? true : options.disableFill
       , width: self.ctx._canvas.width
       , height: self.ctx._canvas.height
-      , shapeColor: options.style.shapeColor || "green"}
+      , shapeColor: options.style.shapeColor || "green"};
 
-    opts.startLon = options.startLon || undefined
-    opts.endLon = options.endLon || undefined
-    opts.startLat = options.startLat || undefined
-    opts.endLat = options.endLat || undefined
-    opts.region = options.region || undefined
-    opts.labelSpace = options.labelSpace || 5
+    opts.startLon = options.startLon || undefined;
+    opts.endLon = options.endLon || undefined;
+    opts.startLat = options.startLat || undefined;
+    opts.endLat = options.endLat || undefined;
+    opts.region = options.region || undefined;
+    opts.labelSpace = options.labelSpace || 5;
 
-    this.ctx.strokeStyle= options.style.stroke || "green"
-    this.ctx.fillStyle=options.style.fill || "green"
+    this.ctx.strokeStyle= options.style.stroke || "green";
+    this.ctx.fillStyle=options.style.fill || "green";
 
-    self.innerMap = new InnerMap(opts, this._canvas)
-    self.innerMap.draw()
+    self.innerMap = new InnerMap(opts, this._canvas);
+    self.innerMap.draw();
 
     if (self.options.markers) {
 
       for (var m in self.options.markers) {
-        self.addMarker(self.options.markers[m])
+        self.addMarker(self.options.markers[m]);
       }
     }
-  })
+  });
 
 }
 
 Map.prototype = Object.create(Canvas.prototype);
 
 Map.prototype.calcSize = function() {
-  this.canvasSize = {width: this.width*2-12, height: this.height*4}
-}
+  this.canvasSize = {width: this.width*2-12, height: this.height*4};
+};
 
 Map.prototype.type = 'map';
 
 Map.prototype.addMarker = function(options) {
   if (!this.innerMap) {
-    throw "error: canvas context does not exist. addMarker() for maps must be called after the map has been added to the screen via screen.append()"
+    throw "error: canvas context does not exist. addMarker() for maps must be called after the map has been added to the screen via screen.append()";
   }
 
-  this.innerMap.addMarker(options)
-}
+  this.innerMap.addMarker(options);
+};
 
 Map.prototype.getOptionsPrototype = function() {
 
@@ -76,11 +76,11 @@ Map.prototype.getOptionsPrototype = function() {
              [  {"lon" : "-79.0000", "lat" : "37.5000", color: "red", char: "X" }
                ,{"lon" : "79.0000", "lat" : "37.5000", color: "blue", char: "O" }
              ]
-  }
-}
+  };
+};
 
 Map.prototype.clearMarkers = function() {
-  this.innerMap.draw()
-}
+  this.innerMap.draw();
+};
 
-module.exports = Map
+module.exports = Map;

--- a/lib/widget/map.js
+++ b/lib/widget/map.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Canvas = require('./canvas')
@@ -13,7 +13,7 @@ function Map(options) {
 
   Canvas.call(this, options);
 
-  this.on("attach", function() {
+  this.on('attach', function() {
 
     options.style = options.style || {};
 
@@ -24,7 +24,7 @@ function Map(options) {
       , disableFill: (options.disableFill === undefined) ? true : options.disableFill
       , width: self.ctx._canvas.width
       , height: self.ctx._canvas.height
-      , shapeColor: options.style.shapeColor || "green"};
+      , shapeColor: options.style.shapeColor || 'green'};
 
     opts.startLon = options.startLon || undefined;
     opts.endLon = options.endLon || undefined;
@@ -33,8 +33,8 @@ function Map(options) {
     opts.region = options.region || undefined;
     opts.labelSpace = options.labelSpace || 5;
 
-    this.ctx.strokeStyle= options.style.stroke || "green";
-    this.ctx.fillStyle=options.style.fill || "green";
+    this.ctx.strokeStyle= options.style.stroke || 'green';
+    this.ctx.fillStyle=options.style.fill || 'green';
 
     self.innerMap = new InnerMap(opts, this._canvas);
     self.innerMap.draw();
@@ -59,7 +59,7 @@ Map.prototype.type = 'map';
 
 Map.prototype.addMarker = function(options) {
   if (!this.innerMap) {
-    throw "error: canvas context does not exist. addMarker() for maps must be called after the map has been added to the screen via screen.append()";
+    throw 'error: canvas context does not exist. addMarker() for maps must be called after the map has been added to the screen via screen.append()';
   }
 
   this.innerMap.addMarker(options);
@@ -73,8 +73,8 @@ Map.prototype.getOptionsPrototype = function() {
     , endLat: 10
     , region: 'us'
     , markers:
-             [  {"lon" : "-79.0000", "lat" : "37.5000", color: "red", char: "X" }
-               ,{"lon" : "79.0000", "lat" : "37.5000", color: "blue", char: "O" }
+             [  {'lon' : '-79.0000', 'lat' : '37.5000', color: 'red', char: 'X' }
+               ,{'lon' : '79.0000', 'lat' : '37.5000', color: 'blue', char: 'O' }
              ]
   };
 };

--- a/lib/widget/markdown.js
+++ b/lib/widget/markdown.js
@@ -56,7 +56,7 @@ Markdown.prototype.getOptionsPrototype = function() {
   return {
     markdown: 'string',
     markdownStyle: 'object'
-  }
+  };
 };
 
 Markdown.prototype.type = 'markdown';

--- a/lib/widget/markdown.js
+++ b/lib/widget/markdown.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Box = blessed.Box
   , marked = require('marked')
@@ -42,7 +42,7 @@ Markdown.prototype.setOptions = function(style) {
 Markdown.prototype.evalStyles = function(options) {
   if (!options.style) return;
   for (var st in options.style) {
-    if (typeof(options.style[st])!="string") continue;
+    if (typeof(options.style[st])!='string') continue;
 
     var tokens = options.style[st].split('.');
     options.style[st] = chalk;

--- a/lib/widget/picture.js
+++ b/lib/widget/picture.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Box = blessed.Box

--- a/lib/widget/picture.js
+++ b/lib/widget/picture.js
@@ -5,7 +5,7 @@ var blessed = require('blessed')
   , pictureTube = require('picture-tuber')
   , fs = require('fs')
   , streams = require('memory-streams')
-  , MemoryStream = require('memorystream')
+  , MemoryStream = require('memorystream');
 
 function Picture(options) {
   if (!(this instanceof Node)) {
@@ -13,11 +13,11 @@ function Picture(options) {
   }
 
   options = options || {};
-  options.cols = options.cols || 50
-  this.options = options
+  options.cols = options.cols || 50;
+  this.options = options;
 
   if (options.file || options.base64) {
-    this.setImage(options)
+    this.setImage(options);
   }
 
   Box.call(this, options);
@@ -27,40 +27,40 @@ Picture.prototype = Object.create(Box.prototype);
 
 Picture.prototype.setImage = function(options) {
 
-  var tube = pictureTube( { cols: options.cols } )
+  var tube = pictureTube( { cols: options.cols } );
 
-  if (options.file) fs.createReadStream(options.file).pipe(tube)
+  if (options.file) fs.createReadStream(options.file).pipe(tube);
   else if (options.base64) {
-    var memStream = new MemoryStream()
-    memStream.pipe(tube)
-    var buf = new Buffer(options.base64, 'base64')
-    memStream.write(buf)
-    memStream.end()
+    var memStream = new MemoryStream();
+    memStream.pipe(tube);
+    var buf = new Buffer(options.base64, 'base64');
+    memStream.write(buf);
+    memStream.end();
   }
 
   this.writer = new streams.WritableStream();
-  tube.pipe(this.writer)
+  tube.pipe(this.writer);
 
   tube.on('end', function() {
     if (options.onReady) {
-      options.onReady()
+      options.onReady();
     }
   });
 
-}
+};
 
 Picture.prototype.render = function() {
-  this.setContent(this.writer.toString())
-  return this._render()
-}
+  this.setContent(this.writer.toString());
+  return this._render();
+};
 
 Picture.prototype.getOptionsPrototype = function() {
 
   return { base64:'AAAA'
-    , cols: 1 }
+    , cols: 1 };
 
-}
+};
 
 Picture.prototype.type = 'picture';
 
-module.exports = Picture
+module.exports = Picture;

--- a/lib/widget/sparkline.js
+++ b/lib/widget/sparkline.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Box = blessed.Box
@@ -20,7 +20,7 @@ function Sparkline(options) {
   Box.call(this, options);
 
 
-  this.on("attach", function() {
+  this.on('attach', function() {
     if (self.options.data) {
       self.setData(self.options.data.titles, self.options.data.data);
     }
@@ -42,7 +42,7 @@ Sparkline.prototype.setData = function(titles, datasets) {
 Sparkline.prototype.getOptionsPrototype = function() {
   return { label: 'Sparkline'
     , tags: true
-    , border: {type: "line", fg: "cyan"}
+    , border: {type: 'line', fg: 'cyan'}
     , width: '50%'
     , height: '50%'
     , style: { fg: 'blue' }

--- a/lib/widget/sparkline.js
+++ b/lib/widget/sparkline.js
@@ -2,11 +2,11 @@
 var blessed = require('blessed')
   , Node = blessed.Node
   , Box = blessed.Box
-  , sparkline = require('sparkline')
+  , sparkline = require('sparkline');
 
 function Sparkline(options) {
 
-  var self = this
+  var self = this;
 
   if (!(this instanceof Node)) {
     return new Sparkline(options);
@@ -14,30 +14,30 @@ function Sparkline(options) {
 
   options = options || {};
   options.bufferLength = options.bufferLength || 30;
-  options.style = options.style || {}
-  options.style.titleFg = options.style.titleFg || 'white'
-  this.options = options
+  options.style = options.style || {};
+  options.style.titleFg = options.style.titleFg || 'white';
+  this.options = options;
   Box.call(this, options);
 
 
   this.on("attach", function() {
     if (self.options.data) {
-      self.setData(self.options.data.titles, self.options.data.data)
+      self.setData(self.options.data.titles, self.options.data.data);
     }
-  })
+  });
 }
 
 Sparkline.prototype = Object.create(Box.prototype);
 
 Sparkline.prototype.setData = function(titles, datasets) {
-  var res = '\r\n'
+  var res = '\r\n';
   for (var i=0; i<titles.length; i++) {
-    res += '{bold}{'+this.options.style.titleFg+'-fg}' + titles[i]+':{/'+this.options.style.titleFg+'-fg}{/bold}\r\n'
-    res += sparkline(datasets[i].slice(0, this.width-2)) + '\r\n\r\n'
+    res += '{bold}{'+this.options.style.titleFg+'-fg}' + titles[i]+':{/'+this.options.style.titleFg+'-fg}{/bold}\r\n';
+    res += sparkline(datasets[i].slice(0, this.width-2)) + '\r\n\r\n';
   }
 
-  this.setContent(res)
-}
+  this.setContent(res);
+};
 
 Sparkline.prototype.getOptionsPrototype = function() {
   return { label: 'Sparkline'
@@ -50,9 +50,9 @@ Sparkline.prototype.getOptionsPrototype = function() {
       data: [ [10, 20, 30, 20, 50, 70, 60, 30, 35, 38]
         , [40, 10, 40, 50, 20, 30, 20, 20, 19, 40] ]
     }
-  }
-}
+  };
+};
 
 Sparkline.prototype.type = 'sparkline';
 
-module.exports = Sparkline
+module.exports = Sparkline;

--- a/lib/widget/table.js
+++ b/lib/widget/table.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed')
   , Node = blessed.Node
   , Box = blessed.Box
@@ -13,13 +13,13 @@ function Table(options) {
   }
 
   if (Array.isArray(options.columnSpacing)) {
-    throw "Error: columnSpacing cannot be an array.\r\n" +
-           "Note: From release 2.0.0 use property columnWidth instead of columnSpacing.\r\n" +
-           "Please refere to the README or to https://github.com/yaronn/blessed-contrib/issues/39";
+    throw 'Error: columnSpacing cannot be an array.\r\n' +
+           'Note: From release 2.0.0 use property columnWidth instead of columnSpacing.\r\n' +
+           'Please refere to the README or to https://github.com/yaronn/blessed-contrib/issues/39';
   }
 
   if (!options.columnWidth) {
-    throw "Error: A table must get columnWidth as a property. Please refer to the README.";
+    throw 'Error: A table must get columnWidth as a property. Please refer to the README.';
   }
 
   options = options || {};
@@ -29,7 +29,7 @@ function Table(options) {
   options.selectedBg = options.selectedBg || 'blue';
   options.fg = options.fg || 'green';
   options.bg = options.bg || '';
-  options.interactive = (typeof options.interactive === "undefined") ? true : options.interactive;
+  options.interactive = (typeof options.interactive === 'undefined') ? true : options.interactive;
   this.options = options;
   Box.call(this, options);
 
@@ -55,7 +55,7 @@ function Table(options) {
 
   this.append(this.rows);
 
-  this.on("attach", function() {
+  this.on('attach', function() {
     if (self.options.data) {
       self.setData(self.options.data);
     }
@@ -83,7 +83,7 @@ Table.prototype.setData = function(table) {
   var self = this;
 
   var dataToString = function(d) {
-    var str = "";
+    var str = '';
     d.forEach(function(r, i) {
       var colsize = self.options.columnWidth[i]
         , strip = stripAnsi(r.toString())
@@ -116,7 +116,7 @@ Table.prototype.getOptionsPrototype = function() {
     , label: 'Active Processes'
     , width: '30%'
     , height: '30%'
-    , border: {type: "line", fg: "cyan"}
+    , border: {type: 'line', fg: 'cyan'}
     , columnSpacing: 10
     , columnWidth: [16, 12]
     , data: { headers: ['col1', 'col2']

--- a/lib/widget/table.js
+++ b/lib/widget/table.js
@@ -2,11 +2,11 @@
 var blessed = require('blessed')
   , Node = blessed.Node
   , Box = blessed.Box
-  , stripAnsi = require('strip-ansi')
+  , stripAnsi = require('strip-ansi');
 
 function Table(options) {
 
-  var self = this
+  var self = this;
 
   if (!(this instanceof Node)) {
     return new Table(options);
@@ -15,22 +15,22 @@ function Table(options) {
   if (Array.isArray(options.columnSpacing)) {
     throw "Error: columnSpacing cannot be an array.\r\n" +
            "Note: From release 2.0.0 use property columnWidth instead of columnSpacing.\r\n" +
-           "Please refere to the README or to https://github.com/yaronn/blessed-contrib/issues/39"
+           "Please refere to the README or to https://github.com/yaronn/blessed-contrib/issues/39";
   }
 
   if (!options.columnWidth) {
-    throw "Error: A table must get columnWidth as a property. Please refer to the README."
+    throw "Error: A table must get columnWidth as a property. Please refer to the README.";
   }
 
   options = options || {};
-  options.columnSpacing = options.columnSpacing==null? 10 : options.columnSpacing
-  options.bold = true
-  options.selectedFg = options.selectedFg || 'white'
-  options.selectedBg = options.selectedBg || 'blue'
-  options.fg = options.fg || 'green'
-  options.bg = options.bg || ''
-  options.interactive = (typeof options.interactive === "undefined") ? true : options.interactive
-  this.options = options
+  options.columnSpacing = options.columnSpacing==null? 10 : options.columnSpacing;
+  options.bold = true;
+  options.selectedFg = options.selectedFg || 'white';
+  options.selectedBg = options.selectedBg || 'blue';
+  options.fg = options.fg || 'green';
+  options.bg = options.bg || '';
+  options.interactive = (typeof options.interactive === "undefined") ? true : options.interactive;
+  this.options = options;
   Box.call(this, options);
 
   this.rows = blessed.list({
@@ -53,13 +53,13 @@ function Table(options) {
     screen: this.screen
   });
 
-  this.append(this.rows)
+  this.append(this.rows);
 
   this.on("attach", function() {
     if (self.options.data) {
-      self.setData(self.options.data)
+      self.setData(self.options.data);
     }
-  })
+  });
 
 }
 
@@ -67,47 +67,47 @@ Table.prototype = Object.create(Box.prototype);
 
 Table.prototype.focus = function(){
   this.rows.focus();
-}
+};
 
 Table.prototype.render = function() {
   if(this.screen.focused == this.rows)
-    this.rows.focus()
+    this.rows.focus();
 
-  this.rows.width = this.width-3
-  this.rows.height = this.height-4
-  Box.prototype.render.call(this)
-}
+  this.rows.width = this.width-3;
+  this.rows.height = this.height-4;
+  Box.prototype.render.call(this);
+};
 
 
 Table.prototype.setData = function(table) {
-  var self = this
+  var self = this;
 
   var dataToString = function(d) {
-    var str = ""
+    var str = "";
     d.forEach(function(r, i) {
       var colsize = self.options.columnWidth[i]
         , strip = stripAnsi(r.toString())
         , ansiLen = r.toString().length - strip.length
-        , spaceLength = colsize - strip.length + self.options.columnSpacing
-      r = r.toString().substring(0, colsize + ansiLen) //compensate for ansi len
+        , spaceLength = colsize - strip.length + self.options.columnSpacing;
+      r = r.toString().substring(0, colsize + ansiLen); //compensate for ansi len
       if (spaceLength < 0) {
         spaceLength = 0;
       }
-      var spaces = new Array(spaceLength).join(' ')
-      str += r + spaces
-    })
-    return str
-  }
+      var spaces = new Array(spaceLength).join(' ');
+      str += r + spaces;
+    });
+    return str;
+  };
 
-  var formatted = []
+  var formatted = [];
 
   table.data.forEach(function(d) {
     var str = dataToString(d);
-    formatted.push(str)
-  })
-  this.setContent(dataToString(table.headers))
-  this.rows.setItems(formatted)
-}
+    formatted.push(str);
+  });
+  this.setContent(dataToString(table.headers));
+  this.rows.setItems(formatted);
+};
 
 Table.prototype.getOptionsPrototype = function() {
   return  { keys: true
@@ -123,9 +123,9 @@ Table.prototype.getOptionsPrototype = function() {
       , data: [ ['a', 'b']
         , ['5', 'u']
         , ['x', '16.1'] ]}
-  }
-}
+  };
+};
 
 Table.prototype.type = 'table';
 
-module.exports = Table
+module.exports = Table;

--- a/lib/widget/tree.js
+++ b/lib/widget/tree.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var blessed = require('blessed'),
   Node = blessed.Node,
   Box = blessed.Box;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blessed-contrib",
-  "version": "4.8.17",
+  "version": "4.8.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blessed-contrib",
-  "version": "4.8.17",
+  "version": "4.8.18",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "npm run lint",
-    "lint": "eslint lib"
+    "lint": "eslint lib",
+    "lint:fix": "eslint lib --fix"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds two new lint rules for quote marks and semicolons. There are probably other lint rules that could be added to keep the code style more consistent, but I think these two rules will have the biggest impact.

**Semicolons**

Semicolons are now always required. The reason for this decision is because there are 480 places where a semicolon could be *added*,

![Wed Oct  2 14:44:34 AEST 2019](https://user-images.githubusercontent.com/16829717/66018893-458d9200-e524-11e9-97c4-ef09bc8e97d3.png)

and if we reverse the rule, there are 499 places where a semicolon could be *removed*.

![Wed Oct  2 14:44:59 AEST 2019](https://user-images.githubusercontent.com/16829717/66018920-68b84180-e524-11e9-93ee-e7b00a8ffd1a.png)

Requiring semicolons is the winner here in terms of the number of affected files, which is the reason why I chose it.

**Quote marks**

Quote marks are now required to be single quotes. Again, the reason just comes down to the number of files affected

Number of changes required if single quotes are enforced:

![Wed Oct  2 14:47:09 AEST 2019](https://user-images.githubusercontent.com/16829717/66019059-01e75800-e525-11e9-8fe3-259801583731.png)

Number of changes required if double quotes are enforced:

![Wed Oct  2 14:47:41 AEST 2019](https://user-images.githubusercontent.com/16829717/66019069-0dd31a00-e525-11e9-8914-aaf3dc4c84ab.png)

I've also added a new npm script, `npm run lint:fix` which can be used to automatically fix lint errors.