### PR TITLE
Allows for file streams to be passed as the file option for pictures.

### DIFF
--- a/lib/widget/picture.js
+++ b/lib/widget/picture.js
@@ -29,8 +29,10 @@ Picture.prototype.setImage = function(options) {
 
   var tube = pictureTube( { cols: options.cols } );
 
-  if (options.file) fs.createReadStream(options.file).pipe(tube);
-  else if (options.base64) {
+  if (options.file) {
+    if (typeof options.file.pipe !== 'function') options.file = fs.createReadStream(options.file);
+    options.file.pipe(tube);
+  } else if (options.base64) {
     var memStream = new MemoryStream();
     memStream.pipe(tube);
     var buf = new Buffer(options.base64, 'base64');


### PR DESCRIPTION
Before this, `options.file` had to be a `String`, `Buffer`, or `URL` (though only a URL on the local filesystem) as it was passed directly to `createReadStream`. I added in a duck typing to only create a read stream if it is not already a stream.

This feature allows for downloading files from a remote URL and passing the readable stream to the picture widget instead of actually downloading a file to some tmpfs location. The only other way I could think of doing this without downloading the file to the filesystem was to convert the fetched file to base64 and use the `options.base64` option picture supports. But this is much more convenient and more efficient to boot.