### PR TITLE
fix(sparkline): incorrect types for `setData`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -214,6 +214,7 @@ declare namespace BlessedContrib {
             calcSize(): void;
 
             setData(data: D): void;
+            setData(titles: string[], data: D): void;
 
             canvasSize: { width: number, height: number }
         }


### PR DESCRIPTION
Sparkline [accepts two arguments](https://github.com/yaronn/blessed-contrib/blob/master/lib/widget/sparkline.js#L32) in `setData` that are not covered by the current types, this PR fixes that.