### PR TITLE
feat: add support for displaying arbitrary numbers in donuts core text

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ Data passed in uses `percent` and `label` to draw the donut graph. Color is opti
 
 Updating the donut is as easy as passing in an array to `setData` using the same array format as in the constructor. Pass in as many objects to the array of data as you want, they will automatically resize and try to fit. However, please note that you will still be restricted to actual screen space.
 
+You can also hardcode a specific numeric into the donut's core display instead of the percentage by passing an `percentAltNumber` property to the data, such as:
+
+`````javascript
+   var donut = contrib.donut({
+	label: 'Test',
+	radius: 8,
+	arcWidth: 3,
+	remainColor: 'black',
+	yPadding: 2,
+	data: [
+	  {percentAltNumber: 50, percent: 80, label: 'web1', color: 'green'}
+	]
+  });
+`````
+
+See an example of this in one of the donuts settings on `./examples/donut.js`.
 
 ### LCD Display
 

--- a/examples/donut.js
+++ b/examples/donut.js
@@ -33,7 +33,7 @@ function updateDonuts(){
 		{percent: parseFloat((pct+0.00) % 1).toFixed(2), label: 'rcp','color':[100,200,170]},
 		{percent: parseFloat((pct+0.25) % 1).toFixed(2), label: 'rcp','color':[128,128,128]},
 		{percent: parseFloat((pct+0.50) % 1).toFixed(2), label: 'rcp','color':[255,0,0]},
-		{percent: parseFloat((pct+0.75) % 1).toFixed(2), label: 'web1', 'color': [255,128,0]}
+		{percentAltNumber: 42, percent: parseFloat((pct+0.75) % 1).toFixed(2), label: 'web1', 'color': [255,128,0]}
 	]);
 	screen.render();
 	pct += 0.01;

--- a/lib/widget/donut.js
+++ b/lib/widget/donut.js
@@ -95,11 +95,10 @@ Donut.prototype.update = function(data) {
   var middle = cheight / 2;
   var spacing = (cwidth - (donuts * radius * 2)) / (donuts + 1);
 
-
-  function drawDonut(label, percent, radius, width, cxx, middle, color){
+  function drawDonut(label, percent, radius, width, cxx, middle, color, percentAltNumber){
     makeRound(100, radius, width, cxx, middle, remainColor );
     makeRound(percent, radius, width, cxx, middle, color);
-    var ptext = parseFloat(percent*100).toFixed(0) + '%';
+    var ptext = percentAltNumber ? percentAltNumber.toFixed(0) : parseFloat(percent*100).toFixed(0) + '%';
     c.fillText(ptext, cxx - Math.round(parseFloat((c.measureText(ptext).width)/2)) + 3, middle);
     c.fillText(label, cxx - Math.round(parseFloat((c.measureText(label).width)/2)) + 3, (middle + radius) + 5);
   }
@@ -111,9 +110,10 @@ Donut.prototype.update = function(data) {
       percent = parseFloat(percent / 100).toFixed(2);
     }
     var label = stat.label;
+    var percentAltNumber = stat.percentAltNumber;
     var color = stat.color || 'green';
     var cxx = left;
-    drawDonut(label, percent, radius, width, cxx, middle, color);
+    drawDonut(label, percent, radius, width, cxx, middle, color, percentAltNumber);
   }
   function makeDonuts(stats){
     for(var l = 0; l<=stats.length-1;l++){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blessed-contrib",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
I added a capability to provide specific numbers that are hard-coded to the Donut's display.
This is what it looks like when I set the last donut's display to `42` as a number. It keeps that hardcoded. It's handy for when you want to display an absolute number and refer to it in the donut, instead of a percentage as part of the donut.

![image](https://user-images.githubusercontent.com/316371/123850848-2d2def80-d923-11eb-9b24-d2a604a8b8c1.png)
