### PR TITLE
fix: add mouse, vi, and keys properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -397,6 +397,9 @@ declare namespace BlessedContrib {
             label?: string
             fg?: string
             bg?: string
+            mouse?: boolean
+            keys?: boolean
+            vi?: boolean
             width?: string
             height?: string
             border?: object


### PR DESCRIPTION
Added the following properties in `TableOptions`
- mouse?: boolean
- keys?: boolean
- vi?: boolean