### PR TITLE
fix(grid): make `hideBorder` work

### DIFF
--- a/lib/layout/grid.js
+++ b/lib/layout/grid.js
@@ -29,7 +29,7 @@ Grid.prototype.set = function(row, col, rowSpan, colSpan, obj, opts) {
   options.left = left + '%';
   options.width = (this.cellWidth * colSpan - widgetSpacing) + '%';
   options.height = (this.cellHeight * rowSpan - widgetSpacing) + '%';
-  if (!this.options.hideBorder)
+  if (!options.hideBorder)
     options.border = {type: 'line', fg: this.options.color || 'cyan'};
 
   var instance = obj(options);


### PR DESCRIPTION
Fixes an issue where `hideBorder: true` does nothing for widgets. See https://github.com/yaronn/blessed-contrib/issues/30#issuecomment-429209961.