### PR TITLE
table dynamic column width based on text length

### DIFF
--- a/lib/widget/table.js
+++ b/lib/widget/table.js
@@ -18,10 +18,6 @@ function Table(options) {
            'Please refere to the README or to https://github.com/yaronn/blessed-contrib/issues/39';
   }
 
-  if (!options.columnWidth) {
-    throw 'Error: A table must get columnWidth as a property. Please refer to the README.';
-  }
-
   options = options || {};
   options.columnSpacing = options.columnSpacing==null? 10 : options.columnSpacing;
   options.bold = true;
@@ -83,10 +79,20 @@ Table.prototype.render = function() {
 Table.prototype.setData = function(table) {
   var self = this;
 
+  var calculatedTableColumnWidths = Array(table.headers.length).fill(0);
+  table.headers.forEach(function(d,i) { calculatedTableColumnWidths[i] = d.length; });
+  table.data.forEach(function(d) {
+    d.forEach(function (t,i) {
+      if(t.length > calculatedTableColumnWidths[i]) {
+        calculatedTableColumnWidths[i] = t.length;
+      }
+    });
+  });
+
   var dataToString = function(d) {
     var str = '';
     d.forEach(function(r, i) {
-      var colsize = self.options.columnWidth[i]
+      var colsize = self?.options?.columnWidth?.[i] || calculatedTableColumnWidths[i]
         , strip = stripAnsi(r.toString())
         , ansiLen = r.toString().length - strip.length
         , spaceLength = colsize - strip.length + self.options.columnSpacing;


### PR DESCRIPTION
This contribution provides the following feature:
- default behavior is to make column as wide as the longest text in the column (headers included) 
- columnWidth option is no longer mandatory
- if `columnWidth` is omitted it will calculate the width based on the length of text in the column (headers and data)
- if `columnWidth` is defined for the column index in the `columnWidth` array it will use that value, if it is `undefined` or `null` it will calculate the value.

<img width="1728" alt="Screenshot 2023-11-25 at 2 45 58 AM" src="https://github.com/yaronn/blessed-contrib/assets/8097956/163ab566-4401-4781-9ea4-824bbb345829">

cc: @lirantal  @yaronn 
